### PR TITLE
Module scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,20 @@ let number = 500;
 Inline components <Counter count="{5}" /> are absolute fine too.
 ````
 
-Use `js exec` blocks instead of script blocks because you can have as many `js exec` blocks ayou want. And I can't remember if I tested script blocks.
+Use `js exec` blocks instead of script blocks because you can have as many `js exec` blocks as you want. And I can't remember if I tested script blocks.
+
+You can also create [module scripts](https://svelte.dev/docs#script_context_module), if you so desire, by using `js module`:
+
+````jsx
+```js module
+  export function someFunction(value) {
+    // some stuff here
+  }
+```
+
+<Counter />
+
+````
 
 ### Break out your try-square
 

--- a/src/md/codeParse.ts
+++ b/src/md/codeParse.ts
@@ -9,6 +9,12 @@ export function codeExec(md) {
       return '';
     }
 
+    if (tokens[idx].info === 'js module') {
+      // add the script content to the svx property but return nothing
+      md.svxmod = md.svxmod.concat(tokens[idx].content);
+      return '';
+    }
+
     // if there is no match, revert to the standard fence renderer
     return defaultRender(tokens, idx, options, env, self);
   };

--- a/test/parse.spec.ts
+++ b/test/parse.spec.ts
@@ -488,3 +488,85 @@ test('files with the wrong filename should return nothing from the function', ()
     })
   ).toBe(undefined);
 });
+
+test('module scripts should be supported', () => {
+  const md = `<svelte:meta />
+
+# Hello world
+
+I like cheese
+
+\`\`\`js module
+  export function random(str) {
+    str.toUpperCase(str);
+  }
+\`\`\`
+
+<Something prop={thingy} />
+`;
+
+  const html = `<svelte:meta />
+<h1>Hello world</h1>
+<p>I like cheese</p>
+<Something prop={thingy} />
+
+<script context="module">
+  export function random(str) {
+    str.toUpperCase(str);
+  }
+
+</script>`;
+  expect(mdsvex().markup({ content: md, filename: 'thing.svexy' }).code).toBe(
+    html
+  );
+});
+
+test('multiple module scripts should be merged into one', () => {
+  const md = `<svelte:meta />
+
+# Hello world
+
+I like cheese
+
+\`\`\`js module
+  export function random(str) {
+    str.toUpperCase(str);
+  }
+\`\`\`
+
+\`\`\`js module
+  export function another(str) {
+    str.toUpperCase(str);
+  }
+\`\`\`
+
+<Something prop={thingy} />
+
+\`\`\`js module
+  export function anothernother(str) {
+    str.toUpperCase(str);
+  }
+\`\`\`
+`;
+
+  const html = `<svelte:meta />
+<h1>Hello world</h1>
+<p>I like cheese</p>
+<Something prop={thingy} />
+
+<script context="module">
+  export function random(str) {
+    str.toUpperCase(str);
+  }
+  export function another(str) {
+    str.toUpperCase(str);
+  }
+  export function anothernother(str) {
+    str.toUpperCase(str);
+  }
+
+</script>`;
+  expect(mdsvex().markup({ content: md, filename: 'thing.svexy' }).code).toBe(
+    html
+  );
+});


### PR DESCRIPTION
Adds support for writing module scripts in markdown using the following syntax:

````jsx
```js module
  export function someFunction(value) {
    // some stuff here
  }
```
````

Includes documentation.