### PR TITLE
docs: Extend --ext notice to export

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,10 +77,11 @@ export default {
 
 > ⚠️ MAKE SURE TO DOCUMENT THIS IN BOTH CLIENT AND SERVER PLUGIN CODE in rollup/webpack
 
-Also, when you run `sapper dev`, you have to run it with the `--ext` flag, like this:
+Also, when you run `sapper dev` or `sapper export`, you have to run it with the `--ext` flag, like this:
 
 ```
 "start": "sapper dev --ext '.svexy .svelte'",
+"export": "sapper export --ext '.svexy .svelte'",
 ```
 
 ## Please, more.


### PR DESCRIPTION
So glad this package exists. Thanks :+1: 

Without this flag a prerendered sapper page will display 404 for these routes.