### PR TITLE
Output meta option to file

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ export default {
           linkify: true,
           highlight: (str, lang) => whatever(str, lang), // this should be a real function if you want to highlight
         },
+        outputMeta: false, // you can pass your frontmatter metadata to separate json files
       }),
     }),
   ],
@@ -179,6 +180,8 @@ This object is also exported from the module script tag, allowing you to import 
 ```js
 import { _metadata } from './article.svexy';
 ```
+
+Also you may need to export your metadata to a separate json file. You can do that by passing `outputMeta` to your MDSveX config.
 
 ### Escaped Curlywurlies
 

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -78,7 +78,7 @@ export function mdsvex({
 
             modules += `export const _metadata = ${json};`;
 
-            if (outputMeta) {
+            if (outputMeta && !fs.existsSync(filename.replace(extension, '.json'))) {
               fs.writeFile(
                 filename.replace(extension, '.json'),
                 json,

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -5,12 +5,16 @@ import { codeExec } from './md/codeParse';
 import * as p from 'path-browserify';
 import { escapeCurly } from './md/escapeCurly';
 import fm from 'front-matter';
+import fs from 'fs';
+import path from 'path';
+
 const extname = p.default.extname;
 
 const defaultOpts = {
   parser: md => md,
   markdownOptions: {},
   extension: '.svexy',
+  outputMeta: false,
 };
 
 export interface svexOptions {
@@ -18,6 +22,7 @@ export interface svexOptions {
   markdownOptions?: object;
   extension?: string;
   layout?: boolean | string;
+  outputMeta?: boolean;
 }
 
 export function mdsvex({
@@ -25,6 +30,7 @@ export function mdsvex({
   markdownOptions = {},
   extension = '.svexy',
   layout,
+  outputMeta = false,
 }: svexOptions = defaultOpts) {
   // this allows the user to modify the instance of markdown-it
   // necessary if they want to add custom plugins, etc.
@@ -69,10 +75,21 @@ export function mdsvex({
           // I'm not sure if these should be available as individual variables
           // concerned about clashes
           if (isAttributes) {
-            modules += `export const _metadata = ${JSON.stringify(
-              attributes
-            )};`;
+            const json = JSON.stringify(attributes);
+
+            modules += `export const _metadata = ${json};`;
+
+            if (outputMeta) {
+              fs.writeFile(
+                filename.replace(extension, '.json'),
+                json,
+                (err) => {
+                  if (err) throw err;
+                }
+              );
+            }
           }
+
           modules = '\n<script context="module">\n' + modules + '\n</script>';
         }
       }

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -6,7 +6,6 @@ import * as p from 'path-browserify';
 import { escapeCurly } from './md/escapeCurly';
 import fm from 'front-matter';
 import fs from 'fs';
-import path from 'path';
 
 const extname = p.default.extname;
 


### PR DESCRIPTION
Hey!

I couldn't figure out how to code split single `_metadata` export, hence I ended up loading way too much stuff of my top page which could use the meta quite nicely to arrange and filter my posts.

So the best solution I found was to simply put it out in good old json.