### PR TITLE
[fix] escape CR LF TAB literals so that they are rendered correctly in final highlight output

### DIFF
--- a/src/transformers/index.js
+++ b/src/transformers/index.js
@@ -426,12 +426,12 @@ export function highlight_blocks({ highlighter: highlight_fn, alias } = {}) {
 		});
 	};
 }
-// escape curlies and backtick to avoid breaking out of {@html `here`} in .svelte
+// escape curlies, backtick, \t, \r, \n to avoid breaking output of {@html `here`} in .svelte
 const escape_svelty = str =>
 	str.replace(
 		/[{}`]/g,
 		c => ({ '{': '&#123;', '}': '&#125;', '`': '&#96;' }[c])
-	);
+	).replace(/\\([trn])/g,'&#92;$1');
 
 export function code_highlight(code, lang) {
 	if (!process.browser) {

--- a/test/it/code_highlighting.test.js
+++ b/test/it/code_highlighting.test.js
@@ -87,6 +87,21 @@ function() {
 	);
 });
 
+highlight('it should escape characters with special meaning inside {@html} used by default highlighter', async () => {
+	const output = await mdsvex().markup({
+		content: `\`\`\`js
+const evil = '{ } \` \\t \\r \\n';
+\`\`\``,
+		filename: 'thing.svx',
+	});
+	assert.equal(
+		'<pre class="language-js">{@html `\n' +
+    '<code class="language-js"><span class="token keyword">const</span> evil <span class="token operator">=</span> <span class="token string">\'&#123; &#125; &#96; &#92;t &#92;r &#92;n\'</span><span class="token punctuation">;</span></code>`}\n' +
+    '</pre>',
+		output.code
+	);
+});
+
 highlight(
 	'it should highlight code when nothing is passed, with a non-default language',
 	async () => {


### PR DESCRIPTION
I found an issue with the improvement i made yesterday.

    ```js
    const s = ["one","two"].join("\n")
    ```

looks like this in the output rendered by a browser:
```
const s = ["one","two"].join("
")
```
Not sure if it's the svelte compiler or the innerHtml at runtime, but additional escaping seems to help.

So here it is. Sorry this slipped through. 