### PR TITLE
docs: replace references to nonexistent config option `layouts` with `layout`

### DIFF
--- a/site/src/routes/_docs.svtext
+++ b/site/src/routes/_docs.svtext
@@ -233,7 +233,7 @@ In some cases you may want different layouts for different types of document, to
 
 ```js
 mdsvex({
-	layouts: {
+	layout: {
 		blog: "./path/to/blog/layout.svelte",
 		article: "./path/to/article/layout.svelte",
 		_: "./path/to/fallback/layout.svelte"
@@ -427,7 +427,7 @@ In some cases you may want different layouts for different types of document. To
 
 ```js
 mdsvex({
-	layouts: {
+	layout: {
 		blog: "./path/to/blog/layout.svelte",
 		article: "./path/to/article/layout.svelte",
 		_: "./path/to/fallback/layout.svelte"


### PR DESCRIPTION
This is a really quick fix that *almost* closes #50, because 
> I'll also add a warning when layouts is used as an option instead of layout. TS types will help here also.

remains unresolved.
