### PR TITLE
Extensions option

### DIFF
--- a/packages/mdsvex/src/index.ts
+++ b/packages/mdsvex/src/index.ts
@@ -198,6 +198,7 @@ function process_layouts(layouts: Layout) {
  * **options** - An options object with the following properties, all are optional.
  *
  * - `extension` - The extension to use for mdsvex files
+ * - `extensions` - The extensions to use for mdsvex files
  * - `layout` - Layouts to apply to mdsvex documents
  * - `frontmatter` - frontmatter options for documents
  * - `highlight` - syntax highlighting options
@@ -213,6 +214,7 @@ export const mdsvex = (options: MdsvexOptions = defaults): Preprocessor => {
 		rehypePlugins = [],
 		smartypants = true,
 		extension = '.svx',
+		extensions,
 		layout = false,
 		highlight = { highlighter: code_highlight },
 		frontmatter,
@@ -231,6 +233,7 @@ export const mdsvex = (options: MdsvexOptions = defaults): Preprocessor => {
 		'rehypePlugins',
 		'smartypants',
 		'extension',
+		'extensions',
 		'layout',
 		'highlight',
 		'frontmatter',
@@ -276,7 +279,8 @@ export const mdsvex = (options: MdsvexOptions = defaults): Preprocessor => {
 
 	return {
 		markup: async ({ content, filename }) => {
-			if (filename.split('.').pop() !== extension.split('.').pop()) return;
+			const extensionsParts = (extensions || [extension]).map(ext => ext.split('.').pop());
+			if (!extensionsParts.includes(filename.split('.').pop())) return;
 
 			const parsed = await parser.process({ contents: content, filename });
 			return { code: parsed.contents as string, map: '' };
@@ -292,6 +296,7 @@ export const mdsvex = (options: MdsvexOptions = defaults): Preprocessor => {
  *
  *
  * - `extension` - The extension to use for mdsvex files
+ * - `extensions` - The extensions to use for mdsvex files
  * - `layout` - Layouts to apply to mdsvex documents
  * - `frontmatter` - frontmatter options for documents
  * - `highlight` - syntax highlighting options
@@ -307,7 +312,8 @@ const _compile = (
 	mdsvex(opts).markup({
 		content: source,
 		filename:
-			(opts && opts.filename) || `file${(opts && opts.extension) || '.svx'}`,
+			(opts && opts.filename) ||
+			`file${(opts && (opts.extensions && opts.extensions[0]) || opts.extension) || '.svx'}`,
 	});
 
 export { _compile as compile };

--- a/packages/mdsvex/src/types.ts
+++ b/packages/mdsvex/src/types.ts
@@ -255,6 +255,15 @@ export interface MdsvexOptions {
 	 */
 	extension?: string;
 	/**
+	 * **extensions** - the extensions to use for mdsvex files. {@link https://mdsvex.com/docs#extensions More details.}
+	 *
+	 *  *example:*
+	 * ```js
+	 * extensions: [".svexy"],
+	 * ```
+	 */
+	extensions?: string[];
+	/**
 	 * **layout** - A string defining a single layout to use for everything or an object of named layouts. When using names layouts, a key of `_` will define the fallback layout. Default: `undefined` (no layouts). {@link https://mdsvex.com/docs#layouts More details.}
 	 *
 	 *  *examples:*

--- a/packages/mdsvex/test/it/mdsvex.test.ts
+++ b/packages/mdsvex/test/it/mdsvex.test.ts
@@ -206,7 +206,7 @@ mdsvex_it('only expected file extension names should work', async () => {
 });
 
 mdsvex_it('the extension name should be customisable', async () => {
-	const output = await mdsvex({ extension: '.jesus' }).markup({
+	const output = await mdsvex({ extensions: ['.jesus'] }).markup({
 		content: `# hello`,
 		filename: 'file.jesus',
 	});
@@ -764,7 +764,7 @@ number: 999
 
 	assert.equal(
 		warning,
-		'mdsvex: Received unknown options: bip, bop, boom. Valid options are: remarkPlugins, rehypePlugins, smartypants, extension, layout, highlight, frontmatter.'
+		'mdsvex: Received unknown options: bip, bop, boom. Valid options are: remarkPlugins, rehypePlugins, smartypants, extension, extensions, layout, highlight, frontmatter.'
 	);
 
 	console.warn = console_warn;
@@ -1125,7 +1125,7 @@ I am some paragraph text
 				'_fixtures',
 				'LayoutTwoWithComponents.svelte'
 			),
-			extension: '.spooky',
+			extensions: ['.spooky'],
 		}
 	);
 

--- a/packages/site/src/components/_cheatsheet.svtext
+++ b/packages/site/src/components/_cheatsheet.svtext
@@ -33,9 +33,9 @@ svelte({
 
     <dl>
       <dt>
-        <a href="docs#extension"><span>extension</span></a>
+        <a href="docs#extensions"><span>extensions</span></a>
       </dt>
-      <dd>use a custom extension</dd>
+      <dd>use custom extensions</dd>
       <dt>
         <a href="docs#smartypants"><span>smartypants</a></span>
       </dt>

--- a/packages/site/src/routes/_docs.svtext
+++ b/packages/site/src/routes/_docs.svtext
@@ -137,7 +137,7 @@ const transformed_code = compile(`
 );
 ```
 
-In addition to the standard mdsvex options, the options object can also take an optional `filename` property which will be passed to mdsvex. There is no significant advantage to doing this but this provided filename may be used for error reporting in the future. The extension you give to this filename must match the extension provided in the options (defaults to `.svx`).
+In addition to the standard mdsvex options, the options object can also take an optional `filename` property which will be passed to mdsvex. There is no significant advantage to doing this but this provided filename may be used for error reporting in the future. The extension you give to this filename must match one of the extensions provided in the options (defaults to `['.svx']`).
 
 ## Options
 
@@ -145,7 +145,7 @@ The preprocessor function accepts an object of options, that allow you to custom
 
 ```typescript
 interface MdsvexOptions {
-	extension: string;
+	extensions: string[];
 	smartypants: boolean | smartypantsOptions;
 	layout: string | { [name: string]: string };
 	remarkPlugins: Array<plugin> | Array<[plugin, plugin_options]>;
@@ -155,13 +155,13 @@ interface MdsvexOptions {
 }
 ```
 
-### `extension`
+### `extensions`
 
 ```ts
-extension: string = ".svx";
+extensions: string[] = [".svx"];
 ```
 
-The `extension` option allows you to set a custom file extension for files written in mdsvex; the default value is `.svx`. Whatever value you choose here must be passed to the `extensions` field of `rollup-plugin-svelte` or `svelte-loader`. If you do not change the default, you must still pass the extension name to the plugin or loader config.
+The `extensions` option allows you to set custom file extensions for files written in mdsvex; the default value is `['.svx']`. Whatever value you choose here must be passed to the `extensions` field of `rollup-plugin-svelte` or `svelte-loader`. If you do not change the default, you must still pass the extension name to the plugin or loader config.
 
 ```js
 export default {
@@ -170,7 +170,7 @@ export default {
 		svelte({
 			extensions: [".svelte", ".custom"],
 			preprocess: mdsvex({
-				extension: ".custom"
+				extensions: [".custom"]
 			})
 		})
 	]

--- a/packages/site/src/routes/docs.svelte
+++ b/packages/site/src/routes/docs.svelte
@@ -27,7 +27,7 @@
 			'Options',
 			'docs#options',
 			[
-				['extension', 'docs#extension', true],
+				['extensions', 'docs#extensions', true],
 				['smartypants', 'docs#smartypants', true],
 				['layout', 'docs#layout', true],
 				['remarkPlugins', 'docs#remarkplugins--rehypeplugins', true],


### PR DESCRIPTION
Adds a new option: `extensions`, which acts just like `extension` but allows for an array instead. Useful for cases when files with different extensions should be processed by MDsveX (for example: including a `.md` file in a `.svx` file, while wanting GitHub to preview the `.md` one). For now, it defaults to an array with `extension` until it is deprecated and `extensions` can get a proper default (ex: `[".svx"]`)

Closes #128 