### PR TITLE
Update svast and improve readmes

### DIFF
--- a/packages/svast/README.md
+++ b/packages/svast/README.md
@@ -11,11 +11,13 @@ This AST seeks to be language agnostic and has no opinion on the contents of any
   - [`UnistPosition`](#unistposition)
   - [`UnistPoint`](#unistpoint)
   - [`UnistData`](#unistdata)
-  - [`Unistparent`](#unistparent)
+  - [`UnistParent`](#unistparent)
 - [SVAST Nodes](#svast-nodes)
   - [`Parent`](#parent)
   - [`Literal`](#literal)
   - [`Root`](#root)
+  - [`BaseTag`](#basetag)
+  - [`Meta](#meta)
   - [`Element`](#element)
   - [`Component`](#component)
   - [`BaseProperty`](#baseproperty)
@@ -110,16 +112,16 @@ The `children` field is a list representing the children of a node.
 interface Parent <: UnistParent {
   children: [
     | SvelteElement
-		| SvelteComponent
-		| Comment
-		| Text
-		| SvelteExpression
-		| VoidBlock
-		| BranchingBlock
-		| IfBlock
-		| EachBlock
-		| AwaitBlock
-		| SvelteTag
+    | SvelteComponent
+    | Comment
+    | Text
+    | SvelteExpression
+    | VoidBlock
+    | BranchingBlock
+    | IfBlock
+    | EachBlock
+    | AwaitBlock
+    | SvelteTag
   ]
 }
 ```
@@ -164,15 +166,15 @@ The `properties` field is a list of the element's attributes and directives. Thi
 
 The `selfClosing` field describes whether or not the source element was self closing or not. This isn't strictly abstract but is helpful in certain cases.
 
-### `SvelteTag`
+### `Meta`
 
 ```idl
 interface SvelteTag <: BaseTag {
-  type: "svelteTag"
+  type: "svelteMeta"
 }
 ```
 
-The `SvelteTag` represent special `svelte` namespace tag names such as `<svelte:self />`.
+The `SvelteTag` represent special `svelte` namespaced tag names such as `<svelte:self />`.
 
 The following input:
 

--- a/packages/svast/index.d.ts
+++ b/packages/svast/index.d.ts
@@ -11,7 +11,7 @@ export type SvelteChild =
 	| VoidBlock
 	| BranchingBlock
 	| EachBlock
-	| SvelteTag;
+	| SvelteMeta;
 
 export interface SvelteParent extends Parent {
 	children: SvelteChild[];
@@ -28,7 +28,7 @@ export interface BaseSvelteTag<T extends string> extends SvelteParent {
 	selfClosing: boolean;
 }
 
-export type SvelteTag = BaseSvelteTag<'svelteTag'>;
+export type SvelteMeta = BaseSvelteTag<'svelteMeta'>;
 
 export type SvelteElement = BaseSvelteTag<'svelteElement'>;
 

--- a/packages/svelte-parse/README.md
+++ b/packages/svelte-parse/README.md
@@ -3,7 +3,11 @@
 It is a parser.
 
 - [Details and Limitations](#details-and-limitations)
-- [Install]
+- [Install](#install-it)
+- [Use](#use-it)
+  - [`parse`](#parse)
+  - [`parseNode`](#parsenode)
+  - [`Point`](#point)
 
 ## Details and limitations
 
@@ -24,7 +28,7 @@ _Note: Error handling is currently a wip/todo, the above represents the intentio
 
 - Javascript expressions are difficult to parse without a JavaScript parser. `svelte-parse` handles them by matching curly braces (as they mark the end of an expression in various contexts) and by ignoring quoted values inside expressions. The biggest shortcoming here is that using curly braces inside regular expressions in an expression will cause the parse to fail in some way unless those braces are balanced. Being as language agnostic as possible is a goal, even if it is unrealistic. The current parser will handle C-like languages with the above caveats.
 - `svelte-parse` does not currently implement the full HTML parsing algorithm and has relatively rudimentary HTML handling. Void tags are handled so `<input/>` and `<input>` are treated the same but unclosed paragraph tags, for example, are not autoclosed. All non-void tags are expected to have a closing tags. I am uncertain how far down this path I'm willing to go.
-- `{#each exp}` blocks do not currently use the [`EachBlock`](https://github.com/pngwn/MDsveX/tree/master/packages/svast) node as defined in [`svast`](https://github.com/pngwn/MDsveX/tree/master/packages/svast) because it is difficult/ impossible to parse in a language agnostic manner. It is currently a [`BranchingBlock`](https://github.com/pngwn/MDsveX/tree/master/packages/svast). The `expression`, `name`, `index`, and `key` are stored as a big blob in the expression field instead of being stored separately as they should be.
+- `{#each exp}` blocks do not currently use the [`EachBlock`](https://github.com/pngwn/MDsveX/tree/master/packages/svast#eachblock) node as defined in [`svast`](https://github.com/pngwn/MDsveX/tree/master/packages/svast) because it is difficult/ impossible to parse in a language agnostic manner. It is currently a [`BranchingBlock`](https://github.com/pngwn/MDsveX/tree/master/packages/svast#branchingblock). The `expression`, `name`, `index`, and `key` are stored as a big blob in the expression field instead of being stored separately as they should be.
 
 ## Install it
 
@@ -60,7 +64,7 @@ interface ParseReturn {
 }
 ```
 
-The `ast` constains the AST that was generated as a result of the parse. This will be a [`Root`](https://github.com/pngwn/MDsveX/tree/master/packages/svast) svast node and is the entry point into the AST.
+The `ast` constains the AST that was generated as a result of the parse. This will be a [`Root`](https://github.com/pngwn/MDsveX/tree/master/packages/svast#root) svast node and is the entry point into the AST.
 
 The `errors` property will be an array of any parsing errors or warnings. I have no idea what this will contain. (error code, error message, position ?)
 
@@ -140,7 +144,7 @@ The `parsed` field is a `Node` object and contains the AST for the `chomped` sou
 
 The `position` field, when present, is a `Point` object and describes the final position of the parsers pointer. If parsing in a loop this should be passed back into the parseNode function.
 
-For an example oif how the `parseNode` function can be used to parse a document you can look at [the implementation of `parse`]().
+For an example oif how the `parseNode` function can be used to parse a document you can look at [the implementation of [`parse`](https://github.com/pngwn/MDsveX/blob/9dcb6cb3d4dcb1aa17d2687925209a955b7cbe0a/packages/svelte-parse/src/main.ts#L1188-L1207) and the [`parse_siblings`](https://github.com/pngwn/MDsveX/blob/9dcb6cb3d4dcb1aa17d2687925209a955b7cbe0a/packages/svelte-parse/src/main.ts#L1144-L1183) function it uses internally..
 
 ### `Point`
 

--- a/packages/svelte-parse/src/main.ts
+++ b/packages/svelte-parse/src/main.ts
@@ -2,7 +2,7 @@ import {
 	Point,
 	Node,
 	BaseSvelteTag,
-	SvelteTag,
+	SvelteMeta,
 	Property,
 	SvelteElement,
 	Directive,
@@ -487,8 +487,8 @@ export function parseNode(opts: ParseNodeOptions): Result | undefined {
 			}
 
 			if (char === COLON) {
-				(current_node as SvelteTag).type = 'svelteTag';
-				(current_node as SvelteTag).tagName = '';
+				(current_node as SvelteMeta).type = 'svelteMeta';
+				(current_node as SvelteMeta).tagName = '';
 				chomp();
 				continue;
 			}
@@ -498,7 +498,7 @@ export function parseNode(opts: ParseNodeOptions): Result | undefined {
 				continue;
 			}
 
-			(current_node as SvelteTag).tagName += value[index];
+			(current_node as SvelteMeta).tagName += value[index];
 			chomp();
 			continue;
 		}
@@ -913,17 +913,17 @@ export function parseNode(opts: ParseNodeOptions): Result | undefined {
 				}
 			}
 
-			(current_node as SvelteTag).value += value[index];
+			(current_node as SvelteMeta).value += value[index];
 			chomp();
 			continue;
 		}
 
 		if (current_state === State.PARSE_CHILDREN) {
 			if (
-				(current_node as SvelteElement | SvelteTag).tagName === 'script' ||
-				(current_node as SvelteElement | SvelteTag).tagName === 'style'
+				(current_node as SvelteElement | SvelteMeta).tagName === 'script' ||
+				(current_node as SvelteElement | SvelteMeta).tagName === 'style'
 			) {
-				(current_node as SvelteElement | SvelteTag).type = 'svelteTag';
+				(current_node as SvelteElement | SvelteMeta).type = 'svelteMeta';
 				_n = {
 					type: 'text',
 					value: '',
@@ -931,7 +931,7 @@ export function parseNode(opts: ParseNodeOptions): Result | undefined {
 				if (generatePositions)
 					//@ts-ignore
 					_n.position = { start: place(), end: {} };
-				(current_node as SvelteTag).children.push(_n as Text);
+				(current_node as SvelteMeta).children.push(_n as Text);
 				push_node(_n);
 
 				set_state(State.IN_SCRIPT_STYLE, true);
@@ -1002,17 +1002,17 @@ export function parseNode(opts: ParseNodeOptions): Result | undefined {
 
 				let current_node_name = closing_tag_name;
 
-				if ((current_node as Node).type === 'svelteTag') {
+				if ((current_node as Node).type === 'svelteMeta') {
 					current_node_name = current_node_name.replace('svelte:', '');
 				}
 
 				if (
 					current_node_name !==
-					(current_node as SvelteTag | SvelteComponent | SvelteElement).tagName
+					(current_node as SvelteMeta | SvelteComponent | SvelteElement).tagName
 				) {
 					console.log(
 						`Was expecting a closing tag for ${
-							(current_node as SvelteTag | SvelteComponent | SvelteElement)
+							(current_node as SvelteMeta | SvelteComponent | SvelteElement)
 								.tagName
 						} but got ${closing_tag_name}`,
 						//@ts-ignore

--- a/packages/svelte-parse/test/element.test.ts
+++ b/packages/svelte-parse/test/element.test.ts
@@ -5,7 +5,7 @@ import {
 	SvelteElement,
 	SvelteComponent,
 	Text,
-	SvelteTag,
+	SvelteMeta,
 	Comment,
 	Node,
 	Point,
@@ -1658,8 +1658,8 @@ element('parses svelte special elements', () => {
 		value: `<svelte:options tag={null} />`,
 	});
 
-	assert.equal(parsed, <SvelteTag>{
-		type: 'svelteTag',
+	assert.equal(parsed, <SvelteMeta>{
+		type: 'svelteMeta',
 		tagName: 'options',
 		properties: [
 			{
@@ -1688,8 +1688,8 @@ element('parses svelte special elements', () => {
 		value: `<svelte:options tag={null} />`,
 	});
 
-	assert.equal(parsed, <SvelteTag>{
-		type: 'svelteTag',
+	assert.equal(parsed, <SvelteMeta>{
+		type: 'svelteMeta',
 		tagName: 'options',
 		properties: [
 			{

--- a/packages/svelte-parse/test/fixtures/01-Button/output.json
+++ b/packages/svelte-parse/test/fixtures/01-Button/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/01-Collapse/output.json
+++ b/packages/svelte-parse/test/fixtures/01-Collapse/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/01-Contributors/output.json
+++ b/packages/svelte-parse/test/fixtures/01-Contributors/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/01-Dialog/output.json
+++ b/packages/svelte-parse/test/fixtures/01-Dialog/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [
 				{
@@ -143,7 +143,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "window",
 			"properties": [
 				{
@@ -216,7 +216,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "options",
 			"properties": [
 				{

--- a/packages/svelte-parse/test/fixtures/01-Dropdown/output.json
+++ b/packages/svelte-parse/test/fixtures/01-Dropdown/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/01-Example/output.json
+++ b/packages/svelte-parse/test/fixtures/01-Example/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/01-Field/output.json
+++ b/packages/svelte-parse/test/fixtures/01-Field/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [
 				{

--- a/packages/svelte-parse/test/fixtures/01-Icon/output.json
+++ b/packages/svelte-parse/test/fixtures/01-Icon/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/01-Input/output.json
+++ b/packages/svelte-parse/test/fixtures/01-Input/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/01-InputOutputToggle/output.json
+++ b/packages/svelte-parse/test/fixtures/01-InputOutputToggle/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/01-IntersectionObserver/output.json
+++ b/packages/svelte-parse/test/fixtures/01-IntersectionObserver/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/01-Lazy/output.json
+++ b/packages/svelte-parse/test/fixtures/01-Lazy/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "component",
 			"properties": [
 				{

--- a/packages/svelte-parse/test/fixtures/01-Message/output.json
+++ b/packages/svelte-parse/test/fixtures/01-Message/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/01-Modal/output.json
+++ b/packages/svelte-parse/test/fixtures/01-Modal/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "window",
 			"properties": [
 				{

--- a/packages/svelte-parse/test/fixtures/01-Nav/output.json
+++ b/packages/svelte-parse/test/fixtures/01-Nav/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/01-Notice/output.json
+++ b/packages/svelte-parse/test/fixtures/01-Notice/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [
 				{
@@ -91,7 +91,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -143,7 +143,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [
 				{

--- a/packages/svelte-parse/test/fixtures/01-Notices/output.json
+++ b/packages/svelte-parse/test/fixtures/01-Notices/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [
 				{
@@ -91,7 +91,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -143,7 +143,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [
 				{

--- a/packages/svelte-parse/test/fixtures/01-Notification/output.json
+++ b/packages/svelte-parse/test/fixtures/01-Notification/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [
 				{

--- a/packages/svelte-parse/test/fixtures/01-NotificationNotice/output.json
+++ b/packages/svelte-parse/test/fixtures/01-NotificationNotice/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/01-PreloadingIndicator/output.json
+++ b/packages/svelte-parse/test/fixtures/01-PreloadingIndicator/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/01-Progress/output.json
+++ b/packages/svelte-parse/test/fixtures/01-Progress/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/01-ReplWidget/output.json
+++ b/packages/svelte-parse/test/fixtures/01-ReplWidget/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/01-ScreenToggle/output.json
+++ b/packages/svelte-parse/test/fixtures/01-ScreenToggle/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/01-Select/output.json
+++ b/packages/svelte-parse/test/fixtures/01-Select/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/01-Snackbar/output.json
+++ b/packages/svelte-parse/test/fixtures/01-Snackbar/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [
 				{

--- a/packages/svelte-parse/test/fixtures/01-Switch/output.json
+++ b/packages/svelte-parse/test/fixtures/01-Switch/output.json
@@ -18,7 +18,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -70,7 +70,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [
 				{

--- a/packages/svelte-parse/test/fixtures/01-Tab/output.json
+++ b/packages/svelte-parse/test/fixtures/01-Tab/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [
 				{

--- a/packages/svelte-parse/test/fixtures/01-Tabs/output.json
+++ b/packages/svelte-parse/test/fixtures/01-Tabs/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [
 				{

--- a/packages/svelte-parse/test/fixtures/01-Tag/output.json
+++ b/packages/svelte-parse/test/fixtures/01-Tag/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/01-Taglist/output.json
+++ b/packages/svelte-parse/test/fixtures/01-Taglist/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/01-ThemeToggler/output.json
+++ b/packages/svelte-parse/test/fixtures/01-ThemeToggler/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -983,7 +983,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/01-Toast/output.json
+++ b/packages/svelte-parse/test/fixtures/01-Toast/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [
 				{

--- a/packages/svelte-parse/test/fixtures/01-Tooltip/output.json
+++ b/packages/svelte-parse/test/fixtures/01-Tooltip/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [
 				{

--- a/packages/svelte-parse/test/fixtures/02-Alert-Alert/output.json
+++ b/packages/svelte-parse/test/fixtures/02-Alert-Alert/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-Alert-Basic/output.json
+++ b/packages/svelte-parse/test/fixtures/02-Alert-Basic/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-Alert-LongMessage/output.json
+++ b/packages/svelte-parse/test/fixtures/02-Alert-LongMessage/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-Avatar-Avatar/output.json
+++ b/packages/svelte-parse/test/fixtures/02-Avatar-Avatar/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,
@@ -439,7 +439,7 @@
 											}
 										},
 										{
-											"type": "svelteTag",
+											"type": "svelteMeta",
 											"tagName": "component",
 											"properties": [
 												{

--- a/packages/svelte-parse/test/fixtures/02-Avatar-Basic/output.json
+++ b/packages/svelte-parse/test/fixtures/02-Avatar-Basic/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-Avatar-Sizes/output.json
+++ b/packages/svelte-parse/test/fixtures/02-Avatar-Sizes/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-Avatar-WithComponent/output.json
+++ b/packages/svelte-parse/test/fixtures/02-Avatar-WithComponent/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-Avatar-WithImage/output.json
+++ b/packages/svelte-parse/test/fixtures/02-Avatar-WithImage/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-Button-Basic/output.json
+++ b/packages/svelte-parse/test/fixtures/02-Button-Basic/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-Button-Button/output.json
+++ b/packages/svelte-parse/test/fixtures/02-Button-Button/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,
@@ -668,7 +668,7 @@
 													}
 												},
 												{
-													"type": "svelteTag",
+													"type": "svelteMeta",
 													"tagName": "component",
 													"properties": [
 														{

--- a/packages/svelte-parse/test/fixtures/02-Button-Icons/output.json
+++ b/packages/svelte-parse/test/fixtures/02-Button-Icons/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-Button-Options/output.json
+++ b/packages/svelte-parse/test/fixtures/02-Button-Options/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-Button-SpinningLoader/output.json
+++ b/packages/svelte-parse/test/fixtures/02-Button-SpinningLoader/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-Button-Styling/output.json
+++ b/packages/svelte-parse/test/fixtures/02-Button-Styling/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-Button-Variations/output.json
+++ b/packages/svelte-parse/test/fixtures/02-Button-Variations/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-Card-Basic/output.json
+++ b/packages/svelte-parse/test/fixtures/02-Card-Basic/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-Card-Card/output.json
+++ b/packages/svelte-parse/test/fixtures/02-Card-Card/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-Card-Clickable/output.json
+++ b/packages/svelte-parse/test/fixtures/02-Card-Clickable/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-Card-Levels/output.json
+++ b/packages/svelte-parse/test/fixtures/02-Card-Levels/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-Checkbox-Basic/output.json
+++ b/packages/svelte-parse/test/fixtures/02-Checkbox-Basic/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-Checkbox-Checkbox/output.json
+++ b/packages/svelte-parse/test/fixtures/02-Checkbox-Checkbox/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-Checkbox-Disabled/output.json
+++ b/packages/svelte-parse/test/fixtures/02-Checkbox-Disabled/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-Chip-Basic/output.json
+++ b/packages/svelte-parse/test/fixtures/02-Chip-Basic/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-Chip-Chip/output.json
+++ b/packages/svelte-parse/test/fixtures/02-Chip-Chip/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-Chip-IsWaiting/output.json
+++ b/packages/svelte-parse/test/fixtures/02-Chip-IsWaiting/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-Chip-Removable/output.json
+++ b/packages/svelte-parse/test/fixtures/02-Chip-Removable/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-Chip-WithAvatar/output.json
+++ b/packages/svelte-parse/test/fixtures/02-Chip-WithAvatar/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-ContentSwitcher-Basic/output.json
+++ b/packages/svelte-parse/test/fixtures/02-ContentSwitcher-Basic/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-ContentSwitcher-ContentSwitcher/output.json
+++ b/packages/svelte-parse/test/fixtures/02-ContentSwitcher-ContentSwitcher/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,
@@ -428,7 +428,7 @@
 																	}
 																},
 																{
-																	"type": "svelteTag",
+																	"type": "svelteMeta",
 																	"tagName": "component",
 																	"properties": [
 																		{

--- a/packages/svelte-parse/test/fixtures/02-DatePicker-Basic/output.json
+++ b/packages/svelte-parse/test/fixtures/02-DatePicker-Basic/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-DatePicker-DateFormat/output.json
+++ b/packages/svelte-parse/test/fixtures/02-DatePicker-DateFormat/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-DatePicker-DatePicker/output.json
+++ b/packages/svelte-parse/test/fixtures/02-DatePicker-DatePicker/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-DatePicker-DayNavigator/output.json
+++ b/packages/svelte-parse/test/fixtures/02-DatePicker-DayNavigator/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-DatePicker-Inline/output.json
+++ b/packages/svelte-parse/test/fixtures/02-DatePicker-Inline/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-DatePicker-MinMax/output.json
+++ b/packages/svelte-parse/test/fixtures/02-DatePicker-MinMax/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-DatePicker-Range/output.json
+++ b/packages/svelte-parse/test/fixtures/02-DatePicker-Range/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-DatePicker-TextOnly/output.json
+++ b/packages/svelte-parse/test/fixtures/02-DatePicker-TextOnly/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-Dropdown-Basic/output.json
+++ b/packages/svelte-parse/test/fixtures/02-Dropdown-Basic/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-Dropdown-Custom/output.json
+++ b/packages/svelte-parse/test/fixtures/02-Dropdown-Custom/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-Dropdown-Dropdown/output.json
+++ b/packages/svelte-parse/test/fixtures/02-Dropdown-Dropdown/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,
@@ -106,7 +106,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "window",
 			"properties": [
 				{

--- a/packages/svelte-parse/test/fixtures/02-Dropdown-Hover/output.json
+++ b/packages/svelte-parse/test/fixtures/02-Dropdown-Hover/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-Dropdown-IsBlock/output.json
+++ b/packages/svelte-parse/test/fixtures/02-Dropdown-IsBlock/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-Dropdown-IsMulti/output.json
+++ b/packages/svelte-parse/test/fixtures/02-Dropdown-IsMulti/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-Dropdown-IsSearchable/output.json
+++ b/packages/svelte-parse/test/fixtures/02-Dropdown-IsSearchable/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-Dropdown-ItemKey/output.json
+++ b/packages/svelte-parse/test/fixtures/02-Dropdown-ItemKey/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-Dropdown-MaxHeight/output.json
+++ b/packages/svelte-parse/test/fixtures/02-Dropdown-MaxHeight/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-Dropdown-SelectedItem/output.json
+++ b/packages/svelte-parse/test/fixtures/02-Dropdown-SelectedItem/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-Dropdown-SelectedItems/output.json
+++ b/packages/svelte-parse/test/fixtures/02-Dropdown-SelectedItems/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-Dropdown-TotallyCustom/output.json
+++ b/packages/svelte-parse/test/fixtures/02-Dropdown-TotallyCustom/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-Dropdown-Width/output.json
+++ b/packages/svelte-parse/test/fixtures/02-Dropdown-Width/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-Dropdown-_CustomDropdown/output.json
+++ b/packages/svelte-parse/test/fixtures/02-Dropdown-_CustomDropdown/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-Dropdown-_CustomList/output.json
+++ b/packages/svelte-parse/test/fixtures/02-Dropdown-_CustomList/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-Dropdown-_DropdownMenu/output.json
+++ b/packages/svelte-parse/test/fixtures/02-Dropdown-_DropdownMenu/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-Dropdown-_DropdownMenuDivider/output.json
+++ b/packages/svelte-parse/test/fixtures/02-Dropdown-_DropdownMenuDivider/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-Dropdown-_DropdownMenuItem/output.json
+++ b/packages/svelte-parse/test/fixtures/02-Dropdown-_DropdownMenuItem/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-Form-Basic/output.json
+++ b/packages/svelte-parse/test/fixtures/02-Form-Basic/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-Form-Form/output.json
+++ b/packages/svelte-parse/test/fixtures/02-Form-Form/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-Icons-AllIcons/output.json
+++ b/packages/svelte-parse/test/fixtures/02-Icons-AllIcons/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,
@@ -385,7 +385,7 @@
 																			}
 																		},
 																		{
-																			"type": "svelteTag",
+																			"type": "svelteMeta",
 																			"tagName": "component",
 																			"properties": [
 																				{

--- a/packages/svelte-parse/test/fixtures/02-Modal-Basic/output.json
+++ b/packages/svelte-parse/test/fixtures/02-Modal-Basic/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-Modal-Modal/output.json
+++ b/packages/svelte-parse/test/fixtures/02-Modal-Modal/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,
@@ -106,7 +106,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "window",
 			"properties": [
 				{

--- a/packages/svelte-parse/test/fixtures/02-Modal-Props/output.json
+++ b/packages/svelte-parse/test/fixtures/02-Modal-Props/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-Notification-Basic/output.json
+++ b/packages/svelte-parse/test/fixtures/02-Notification-Basic/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-Notification-Notification/output.json
+++ b/packages/svelte-parse/test/fixtures/02-Notification-Notification/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,
@@ -106,7 +106,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "options",
 			"properties": [
 				{

--- a/packages/svelte-parse/test/fixtures/02-NumberInput-Basic/output.json
+++ b/packages/svelte-parse/test/fixtures/02-NumberInput-Basic/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-NumberInput-NumberInput/output.json
+++ b/packages/svelte-parse/test/fixtures/02-NumberInput-NumberInput/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-Pagination-Basic/output.json
+++ b/packages/svelte-parse/test/fixtures/02-Pagination-Basic/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-Pagination-Pagination/output.json
+++ b/packages/svelte-parse/test/fixtures/02-Pagination-Pagination/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-ProgressBar-Basic/output.json
+++ b/packages/svelte-parse/test/fixtures/02-ProgressBar-Basic/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-ProgressBar-ProgressBar/output.json
+++ b/packages/svelte-parse/test/fixtures/02-ProgressBar-ProgressBar/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-Radio-Basic/output.json
+++ b/packages/svelte-parse/test/fixtures/02-Radio-Basic/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-Radio-Radio/output.json
+++ b/packages/svelte-parse/test/fixtures/02-Radio-Radio/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-RangeSlider-Basic/output.json
+++ b/packages/svelte-parse/test/fixtures/02-RangeSlider-Basic/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-RangeSlider-RangeSlider/output.json
+++ b/packages/svelte-parse/test/fixtures/02-RangeSlider-RangeSlider/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-RangeSlider-RangeSliderHandles/output.json
+++ b/packages/svelte-parse/test/fixtures/02-RangeSlider-RangeSliderHandles/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-RangeSlider-RangeSliderSteps/output.json
+++ b/packages/svelte-parse/test/fixtures/02-RangeSlider-RangeSliderSteps/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-RangeSlider-RangeSliderTooltips/output.json
+++ b/packages/svelte-parse/test/fixtures/02-RangeSlider-RangeSliderTooltips/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-RangeSlider-RangeSliderUpdateWhenSliding/output.json
+++ b/packages/svelte-parse/test/fixtures/02-RangeSlider-RangeSliderUpdateWhenSliding/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-Search-Basic/output.json
+++ b/packages/svelte-parse/test/fixtures/02-Search-Basic/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-Search-Debounce/output.json
+++ b/packages/svelte-parse/test/fixtures/02-Search-Debounce/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-Search-Placeholder/output.json
+++ b/packages/svelte-parse/test/fixtures/02-Search-Placeholder/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-Search-Search/output.json
+++ b/packages/svelte-parse/test/fixtures/02-Search-Search/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-Spinner-Basic/output.json
+++ b/packages/svelte-parse/test/fixtures/02-Spinner-Basic/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-Spinner-Spinner/output.json
+++ b/packages/svelte-parse/test/fixtures/02-Spinner-Spinner/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-Switch-Basic/output.json
+++ b/packages/svelte-parse/test/fixtures/02-Switch-Basic/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-Switch-Switch/output.json
+++ b/packages/svelte-parse/test/fixtures/02-Switch-Switch/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-Table-Basic/output.json
+++ b/packages/svelte-parse/test/fixtures/02-Table-Basic/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-Table-Table/output.json
+++ b/packages/svelte-parse/test/fixtures/02-Table-Table/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,
@@ -869,7 +869,7 @@
 																																	}
 																																},
 																																{
-																																	"type": "svelteTag",
+																																	"type": "svelteMeta",
 																																	"tagName": "component",
 																																	"properties": [
 																																		{
@@ -1223,7 +1223,7 @@
 																															}
 																														},
 																														{
-																															"type": "svelteTag",
+																															"type": "svelteMeta",
 																															"tagName": "component",
 																															"properties": [
 																																{
@@ -2425,7 +2425,7 @@
 																											}
 																										},
 																										{
-																											"type": "svelteTag",
+																											"type": "svelteMeta",
 																											"tagName": "component",
 																											"properties": [
 																												{

--- a/packages/svelte-parse/test/fixtures/02-Tabs-Basic/output.json
+++ b/packages/svelte-parse/test/fixtures/02-Tabs-Basic/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-Tabs-Tabs/output.json
+++ b/packages/svelte-parse/test/fixtures/02-Tabs-Tabs/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,
@@ -1035,7 +1035,7 @@
 															}
 														},
 														{
-															"type": "svelteTag",
+															"type": "svelteMeta",
 															"tagName": "component",
 															"properties": [
 																{

--- a/packages/svelte-parse/test/fixtures/02-Tabs-_tab1/output.json
+++ b/packages/svelte-parse/test/fixtures/02-Tabs-_tab1/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-Tabs-_tab2/output.json
+++ b/packages/svelte-parse/test/fixtures/02-Tabs-_tab2/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-Tag-Basic/output.json
+++ b/packages/svelte-parse/test/fixtures/02-Tag-Basic/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-Tag-Tag/output.json
+++ b/packages/svelte-parse/test/fixtures/02-Tag-Tag/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,
@@ -387,7 +387,7 @@
 													}
 												},
 												{
-													"type": "svelteTag",
+													"type": "svelteMeta",
 													"tagName": "component",
 													"properties": [
 														{

--- a/packages/svelte-parse/test/fixtures/02-TextInput-Basic/output.json
+++ b/packages/svelte-parse/test/fixtures/02-TextInput-Basic/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-TextInput-TextInput/output.json
+++ b/packages/svelte-parse/test/fixtures/02-TextInput-TextInput/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-TimeMenu-Basic/output.json
+++ b/packages/svelte-parse/test/fixtures/02-TimeMenu-Basic/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-TimeMenu-TimeMenu/output.json
+++ b/packages/svelte-parse/test/fixtures/02-TimeMenu-TimeMenu/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-TimeMenu-_Menu/output.json
+++ b/packages/svelte-parse/test/fixtures/02-TimeMenu-_Menu/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-TimeMenu-_TimeOptions/output.json
+++ b/packages/svelte-parse/test/fixtures/02-TimeMenu-_TimeOptions/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-TimeSelect-Basic/output.json
+++ b/packages/svelte-parse/test/fixtures/02-TimeSelect-Basic/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-TimeSelect-TimeSelect/output.json
+++ b/packages/svelte-parse/test/fixtures/02-TimeSelect-TimeSelect/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-Tooltip-Basic/output.json
+++ b/packages/svelte-parse/test/fixtures/02-Tooltip-Basic/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/02-Tooltip-Tooltip/output.json
+++ b/packages/svelte-parse/test/fixtures/02-Tooltip-Tooltip/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-00-actions-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-00-actions-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-00-animate-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-00-animate-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-00-classes-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-00-classes-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-00-context-api-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-00-context-api-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-00-context-api-Map/output.json
+++ b/packages/svelte-parse/test/fixtures/03-00-context-api-Map/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-00-context-api-MapMarker/output.json
+++ b/packages/svelte-parse/test/fixtures/03-00-context-api-MapMarker/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-00-debug-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-00-debug-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-00-declaring-props-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-00-declaring-props-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-00-declaring-props-Nested/output.json
+++ b/packages/svelte-parse/test/fixtures/03-00-declaring-props-Nested/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-00-dom-events-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-00-dom-events-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-00-easing-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-00-easing-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-00-easing-Controls/output.json
+++ b/packages/svelte-parse/test/fixtures/03-00-easing-Controls/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-00-easing-Grid/output.json
+++ b/packages/svelte-parse/test/fixtures/03-00-easing-Grid/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,
@@ -106,7 +106,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "options",
 			"properties": [
 				{

--- a/packages/svelte-parse/test/fixtures/03-00-hello-world-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-00-hello-world-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-00-if-blocks-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-00-if-blocks-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-00-onmount-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-00-onmount-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-00-reactive-assignments-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-00-reactive-assignments-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-00-slots-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-00-slots-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-00-slots-Box/output.json
+++ b/packages/svelte-parse/test/fixtures/03-00-slots-Box/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-00-svelte-self-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-00-svelte-self-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-00-svelte-self-File/output.json
+++ b/packages/svelte-parse/test/fixtures/03-00-svelte-self-File/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-00-svelte-self-Folder/output.json
+++ b/packages/svelte-parse/test/fixtures/03-00-svelte-self-Folder/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,
@@ -376,7 +376,7 @@
 																			}
 																		},
 																		{
-																			"type": "svelteTag",
+																			"type": "svelteMeta",
 																			"tagName": "self",
 																			"properties": [
 																				{

--- a/packages/svelte-parse/test/fixtures/03-00-text-inputs-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-00-text-inputs-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-00-transition-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-00-transition-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-00-tweened-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-00-tweened-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-00-writable-stores-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-00-writable-stores-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-00-writable-stores-Decrementer/output.json
+++ b/packages/svelte-parse/test/fixtures/03-00-writable-stores-Decrementer/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-00-writable-stores-Incrementer/output.json
+++ b/packages/svelte-parse/test/fixtures/03-00-writable-stores-Incrementer/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-00-writable-stores-Resetter/output.json
+++ b/packages/svelte-parse/test/fixtures/03-00-writable-stores-Resetter/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-01-adding-parameters-to-actions-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-01-adding-parameters-to-actions-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-01-adding-parameters-to-transitions-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-01-adding-parameters-to-transitions-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-01-auto-subscriptions-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-01-auto-subscriptions-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-01-auto-subscriptions-Decrementer/output.json
+++ b/packages/svelte-parse/test/fixtures/03-01-auto-subscriptions-Decrementer/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-01-auto-subscriptions-Incrementer/output.json
+++ b/packages/svelte-parse/test/fixtures/03-01-auto-subscriptions-Incrementer/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-01-auto-subscriptions-Resetter/output.json
+++ b/packages/svelte-parse/test/fixtures/03-01-auto-subscriptions-Resetter/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-01-class-shorthand-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-01-class-shorthand-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-01-clock-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-01-clock-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-01-default-values-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-01-default-values-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-01-default-values-Nested/output.json
+++ b/packages/svelte-parse/test/fixtures/03-01-default-values-Nested/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-01-dynamic-attributes-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-01-dynamic-attributes-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-01-else-blocks-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-01-else-blocks-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-01-hacker-news-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-01-hacker-news-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,
@@ -106,7 +106,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "window",
 			"properties": [
 				{

--- a/packages/svelte-parse/test/fixtures/03-01-hacker-news-Comment/output.json
+++ b/packages/svelte-parse/test/fixtures/03-01-hacker-news-Comment/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,
@@ -396,7 +396,7 @@
 											}
 										},
 										{
-											"type": "svelteTag",
+											"type": "svelteMeta",
 											"tagName": "self",
 											"properties": [
 												{

--- a/packages/svelte-parse/test/fixtures/03-01-hacker-news-Item/output.json
+++ b/packages/svelte-parse/test/fixtures/03-01-hacker-news-Item/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-01-hacker-news-List/output.json
+++ b/packages/svelte-parse/test/fixtures/03-01-hacker-news-List/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-01-hacker-news-Summary/output.json
+++ b/packages/svelte-parse/test/fixtures/03-01-hacker-news-Summary/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-01-inline-handlers-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-01-inline-handlers-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-01-module-exports-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-01-module-exports-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-01-module-exports-AudioPlayer/output.json
+++ b/packages/svelte-parse/test/fixtures/03-01-module-exports-AudioPlayer/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [
 				{
@@ -91,7 +91,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -143,7 +143,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-01-numeric-inputs-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-01-numeric-inputs-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-01-ondestroy-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-01-ondestroy-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-01-reactive-declarations-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-01-reactive-declarations-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-01-slot-fallbacks-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-01-slot-fallbacks-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-01-slot-fallbacks-Box/output.json
+++ b/packages/svelte-parse/test/fixtures/03-01-slot-fallbacks-Box/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-01-spring-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-01-spring-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-01-svelte-component-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-01-svelte-component-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -317,7 +317,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "component",
 			"properties": [
 				{

--- a/packages/svelte-parse/test/fixtures/03-01-svelte-component-BlueThing/output.json
+++ b/packages/svelte-parse/test/fixtures/03-01-svelte-component-BlueThing/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-01-svelte-component-GreenThing/output.json
+++ b/packages/svelte-parse/test/fixtures/03-01-svelte-component-GreenThing/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-01-svelte-component-RedThing/output.json
+++ b/packages/svelte-parse/test/fixtures/03-01-svelte-component-RedThing/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-02-bar-chart-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-02-bar-chart-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-02-checkbox-inputs-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-02-checkbox-inputs-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-02-else-if-blocks-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-02-else-if-blocks-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-02-event-modifiers-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-02-event-modifiers-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-02-immutable-data-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-02-immutable-data-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "options",
 			"properties": [
 				{
@@ -53,7 +53,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-02-immutable-data-ImmutableTodo/output.json
+++ b/packages/svelte-parse/test/fixtures/03-02-immutable-data-ImmutableTodo/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "options",
 			"properties": [
 				{
@@ -53,7 +53,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -105,7 +105,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-02-immutable-data-MutableTodo/output.json
+++ b/packages/svelte-parse/test/fixtures/03-02-immutable-data-MutableTodo/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-02-in-and-out-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-02-in-and-out-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-02-named-slots-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-02-named-slots-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-02-named-slots-ContactCard/output.json
+++ b/packages/svelte-parse/test/fixtures/03-02-named-slots-ContactCard/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-02-reactive-statements-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-02-reactive-statements-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-02-readable-stores-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-02-readable-stores-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-02-spread-props-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-02-spread-props-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-02-spread-props-Info/output.json
+++ b/packages/svelte-parse/test/fixtures/03-02-spread-props-Info/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-02-styling-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-02-styling-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-02-svelte-window-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-02-svelte-window-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,
@@ -106,7 +106,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "window",
 			"properties": [
 				{

--- a/packages/svelte-parse/test/fixtures/03-02-update-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-02-update-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-03-area-chart-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-03-area-chart-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -2116,7 +2116,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-03-component-events-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-03-component-events-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-03-component-events-Inner/output.json
+++ b/packages/svelte-parse/test/fixtures/03-03-component-events-Inner/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-03-custom-css-transitions-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-03-custom-css-transitions-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-03-derived-stores-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-03-derived-stores-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-03-each-blocks-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-03-each-blocks-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-03-group-inputs-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-03-group-inputs-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-03-nested-components-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-03-nested-components-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-03-slot-props-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-03-slot-props-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-03-slot-props-Hoverable/output.json
+++ b/packages/svelte-parse/test/fixtures/03-03-slot-props-Hoverable/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-03-svelte-window-bindings-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-03-svelte-window-bindings-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "window",
 			"properties": [
 				{
@@ -923,7 +923,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-03-tick-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-03-tick-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-04-custom-js-transitions-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-04-custom-js-transitions-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-04-custom-stores-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-04-custom-stores-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-04-event-forwarding-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-04-event-forwarding-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-04-event-forwarding-Inner/output.json
+++ b/packages/svelte-parse/test/fixtures/03-04-event-forwarding-Inner/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-04-event-forwarding-Outer/output.json
+++ b/packages/svelte-parse/test/fixtures/03-04-event-forwarding-Outer/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-04-html-tags-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-04-html-tags-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-04-keyed-each-blocks-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-04-keyed-each-blocks-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-04-keyed-each-blocks-Thing/output.json
+++ b/packages/svelte-parse/test/fixtures/03-04-keyed-each-blocks-Thing/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -340,7 +340,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-04-modal-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-04-modal-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-04-modal-Modal/output.json
+++ b/packages/svelte-parse/test/fixtures/03-04-modal-Modal/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "window",
 			"properties": [
 				{
@@ -748,7 +748,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-04-scatterplot-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-04-scatterplot-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-04-scatterplot-Scatterplot/output.json
+++ b/packages/svelte-parse/test/fixtures/03-04-scatterplot-Scatterplot/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "window",
 			"properties": [
 				{
@@ -1695,7 +1695,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-04-svelte-body-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-04-svelte-body-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,
@@ -106,7 +106,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "body",
 			"properties": [
 				{

--- a/packages/svelte-parse/test/fixtures/03-04-textarea-inputs-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-04-textarea-inputs-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-05-await-blocks-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-05-await-blocks-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-05-dom-event-forwarding-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-05-dom-event-forwarding-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-05-dom-event-forwarding-CustomButton/output.json
+++ b/packages/svelte-parse/test/fixtures/03-05-dom-event-forwarding-CustomButton/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-05-file-inputs-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-05-file-inputs-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-05-svelte-head-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-05-svelte-head-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "head",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-05-svg-transitions-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-05-svg-transitions-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-05-transition-events-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-05-transition-events-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-06-deferred-transitions-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-06-deferred-transitions-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -1753,7 +1753,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-06-select-bindings-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-06-select-bindings-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-07-multiple-select-bindings-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-07-multiple-select-bindings-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-08-each-block-bindings-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-08-each-block-bindings-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-09-media-elements-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-09-media-elements-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-10-dimensions-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-10-dimensions-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-11-bind-this-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-11-bind-this-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-12-component-bindings-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-12-component-bindings-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-12-component-bindings-Keypad/output.json
+++ b/packages/svelte-parse/test/fixtures/03-12-component-bindings-Keypad/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-button-index/output.json
+++ b/packages/svelte-parse/test/fixtures/03-button-index/output.json
@@ -2521,7 +2521,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-container-index/output.json
+++ b/packages/svelte-parse/test/fixtures/03-container-index/output.json
@@ -184,7 +184,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [
 				{
@@ -273,7 +273,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-css-in-js-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-css-in-js-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-css-in-js-Hero/output.json
+++ b/packages/svelte-parse/test/fixtures/03-css-in-js-Hero/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-divider-index/output.json
+++ b/packages/svelte-parse/test/fixtures/03-divider-index/output.json
@@ -167,7 +167,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [
 				{
@@ -256,7 +256,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-flag-index/output.json
+++ b/packages/svelte-parse/test/fixtures/03-flag-index/output.json
@@ -147,7 +147,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [
 				{
@@ -236,7 +236,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-header-index/output.json
+++ b/packages/svelte-parse/test/fixtures/03-header-index/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-icon-index/output.json
+++ b/packages/svelte-parse/test/fixtures/03-icon-index/output.json
@@ -147,7 +147,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [
 				{
@@ -236,7 +236,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-image-index/output.json
+++ b/packages/svelte-parse/test/fixtures/03-image-index/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-input-index/output.json
+++ b/packages/svelte-parse/test/fixtures/03-input-index/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-loader-index/output.json
+++ b/packages/svelte-parse/test/fixtures/03-loader-index/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-placeholder-Line/output.json
+++ b/packages/svelte-parse/test/fixtures/03-placeholder-Line/output.json
@@ -90,7 +90,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-placeholder-index/output.json
+++ b/packages/svelte-parse/test/fixtures/03-placeholder-index/output.json
@@ -1704,7 +1704,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [
 				{
@@ -1793,7 +1793,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-rail-index/output.json
+++ b/packages/svelte-parse/test/fixtures/03-rail-index/output.json
@@ -184,7 +184,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [
 				{
@@ -273,7 +273,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-reveal-index/output.json
+++ b/packages/svelte-parse/test/fixtures/03-reveal-index/output.json
@@ -701,7 +701,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [
 				{
@@ -790,7 +790,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-segment-SegmentGroup/output.json
+++ b/packages/svelte-parse/test/fixtures/03-segment-SegmentGroup/output.json
@@ -114,7 +114,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [
 				{
@@ -203,7 +203,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-segment-index/output.json
+++ b/packages/svelte-parse/test/fixtures/03-segment-index/output.json
@@ -167,7 +167,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [
 				{
@@ -256,7 +256,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-step-StepContent/output.json
+++ b/packages/svelte-parse/test/fixtures/03-step-StepContent/output.json
@@ -142,7 +142,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [
 				{
@@ -231,7 +231,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-step-StepDescription/output.json
+++ b/packages/svelte-parse/test/fixtures/03-step-StepDescription/output.json
@@ -142,7 +142,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [
 				{
@@ -231,7 +231,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-step-StepGroup/output.json
+++ b/packages/svelte-parse/test/fixtures/03-step-StepGroup/output.json
@@ -114,7 +114,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [
 				{
@@ -203,7 +203,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-step-StepTitle/output.json
+++ b/packages/svelte-parse/test/fixtures/03-step-StepTitle/output.json
@@ -142,7 +142,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [
 				{
@@ -231,7 +231,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-step-index/output.json
+++ b/packages/svelte-parse/test/fixtures/03-step-index/output.json
@@ -490,7 +490,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [
 				{
@@ -579,7 +579,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-text-index/output.json
+++ b/packages/svelte-parse/test/fixtures/03-text-index/output.json
@@ -167,7 +167,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [
 				{
@@ -256,7 +256,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/03-write-less-code-App/output.json
+++ b/packages/svelte-parse/test/fixtures/03-write-less-code-App/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/binding-shorthand/output.json
+++ b/packages/svelte-parse/test/fixtures/binding-shorthand/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/binding/output.json
+++ b/packages/svelte-parse/test/fixtures/binding/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/component-dynamic/output.json
+++ b/packages/svelte-parse/test/fixtures/component-dynamic/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "component",
 			"properties": [
 				{

--- a/packages/svelte-parse/test/fixtures/css/output.json
+++ b/packages/svelte-parse/test/fixtures/css/output.json
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "style",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/dynamic-import/output.json
+++ b/packages/svelte-parse/test/fixtures/dynamic-import/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/each-block-destructured/output.json
+++ b/packages/svelte-parse/test/fixtures/each-block-destructured/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/refs/output.json
+++ b/packages/svelte-parse/test/fixtures/refs/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/script-comment-only/output.json
+++ b/packages/svelte-parse/test/fixtures/script-comment-only/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/script-comment-trailing-multiline/output.json
+++ b/packages/svelte-parse/test/fixtures/script-comment-trailing-multiline/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/script-comment-trailing/output.json
+++ b/packages/svelte-parse/test/fixtures/script-comment-trailing/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/script/output.json
+++ b/packages/svelte-parse/test/fixtures/script/output.json
@@ -2,7 +2,7 @@
 	"type": "root",
 	"children": [
 		{
-			"type": "svelteTag",
+			"type": "svelteMeta",
 			"tagName": "script",
 			"properties": [],
 			"selfClosing": false,

--- a/packages/svelte-parse/test/fixtures/self-reference/output.json
+++ b/packages/svelte-parse/test/fixtures/self-reference/output.json
@@ -42,7 +42,7 @@
 							}
 						},
 						{
-							"type": "svelteTag",
+							"type": "svelteMeta",
 							"tagName": "self",
 							"properties": [
 								{

--- a/packages/svelte-parse/test/positions.test.ts
+++ b/packages/svelte-parse/test/positions.test.ts
@@ -4,7 +4,7 @@ import * as assert from 'uvu/assert';
 import {
 	SvelteElement,
 	Text,
-	SvelteTag,
+	SvelteMeta,
 	SvelteExpression,
 	VoidBlock,
 	Comment,
@@ -156,8 +156,8 @@ position('tracks the location of self-closing elements', () => {
 		value: `<svelte:options />`,
 	});
 
-	assert.equal(parsed, <SvelteTag>{
-		type: 'svelteTag',
+	assert.equal(parsed, <SvelteMeta>{
+		type: 'svelteMeta',
 		tagName: 'options',
 		properties: [],
 		selfClosing: true,
@@ -177,8 +177,8 @@ position('tracks the location of attributes', () => {
 		value: `<svelte:options tag={null} />`,
 	});
 
-	assert.equal(parsed, <SvelteTag>{
-		type: 'svelteTag',
+	assert.equal(parsed, <SvelteMeta>{
+		type: 'svelteMeta',
 		tagName: 'options',
 		properties: [
 			{
@@ -418,7 +418,7 @@ position('tracks the location of a complex node', () => {
 		type: 'root',
 		children: [
 			{
-				type: 'svelteTag',
+				type: 'svelteMeta',
 				tagName: 'script',
 				properties: [],
 				selfClosing: false,

--- a/packages/svelte-parse/test/siblings.test.ts
+++ b/packages/svelte-parse/test/siblings.test.ts
@@ -422,7 +422,7 @@ siblings('parses script tags ignoring the contents', () => {
 		type: 'root',
 		children: [
 			{
-				type: 'svelteTag',
+				type: 'svelteMeta',
 				tagName: 'script',
 				properties: [],
 				selfClosing: false,
@@ -445,7 +445,7 @@ Hello friends</script>`,
 		type: 'root',
 		children: [
 			{
-				type: 'svelteTag',
+				type: 'svelteMeta',
 				tagName: 'script',
 				properties: [
 					{
@@ -480,7 +480,7 @@ Hello friends</style>`,
 		type: 'root',
 		children: [
 			{
-				type: 'svelteTag',
+				type: 'svelteMeta',
 				tagName: 'style',
 				properties: [
 					{
@@ -514,7 +514,7 @@ siblings('parses style tags ignoring the contents', () => {
 		type: 'root',
 		children: [
 			{
-				type: 'svelteTag',
+				type: 'svelteMeta',
 				tagName: 'head',
 				properties: [
 					{


### PR DESCRIPTION
This changes the `svelteTag` node to `svelteMeta` along will all necessary typescript types and documentation.

Also improves the readme for both `svelte-parse` and `svast`.