### PR TITLE
Remove: unused export propety embedded

### DIFF
--- a/packages/site/src/components/Repl/Output/index.svelte
+++ b/packages/site/src/components/Repl/Output/index.svelte
@@ -15,7 +15,6 @@
   export let status;
   export let sourceErrorLoc = null;
   export let runtimeError = null;
-  export let embedded = false;
   export let relaxed = false;
   export let injectedJS;
   export let injectedCSS;

--- a/packages/site/src/components/Repl/Repl.svelte
+++ b/packages/site/src/components/Repl/Repl.svelte
@@ -11,7 +11,6 @@
   export let workersUrl;
   export let packagesUrl = "https://unpkg.com";
   export let svelteUrl = `${packagesUrl}/svelte`;
-  export let embedded = true;
   export let orientation = "columns";
   export let relaxed = false;
   export let fixed = false;
@@ -248,7 +247,6 @@
         {svelteUrl}
         {workersUrl}
         {status}
-        {embedded}
         {relaxed}
         {injectedJS}
         {injectedCSS} />


### PR DESCRIPTION
fix: Output has unused export property 'embedded'.  warning log

All logs
```bash
MDsveX/packages/site/src/components/Repl/Output/index.svelte
Output has unused export property 'embedded'. If it is for external reference only, please consider using `export const embedded`
16:   export let sourceErrorLoc = null;
17:   export let runtimeError = null;
18:   export let embedded = false;
                 ^
19:   export let relaxed = false;
20:   export let injectedJS;
```