### PR TITLE
Remove: unused variables

### DIFF
--- a/packages/site/src/components/Repl/Output/Viewer.svelte
+++ b/packages/site/src/components/Repl/Output/Viewer.svelte
@@ -22,7 +22,6 @@
   export let relaxed = false;
   export let injectedJS = "";
   export let injectedCSS = "";
-  export let funky = false;
 
   let iframe;
   let pending_imports = 0;

--- a/packages/site/src/components/Repl/Output/index.svelte
+++ b/packages/site/src/components/Repl/Output/index.svelte
@@ -13,7 +13,6 @@
   export let svelteUrl;
   export let workersUrl;
   export let status;
-  export let sourceErrorLoc = null;
   export let runtimeError = null;
   export let relaxed = false;
   export let injectedJS;


### PR DESCRIPTION
All cleard ` unused export property...` warning log.

logs
```
MDsveX/packages/site/src/components/Repl/Output/index.svelte
Output has unused export property 'sourceErrorLoc'. If it is for external reference only, please consider using `export const sourceErrorLoc`
   export let workersUrl;
   export let status;
   export let sourceErrorLoc = null;
                 ^
  export let runtimeError = null;
  export let relaxed = false;

MDsveX/packages/site/src/components/Repl/Output/Viewer.svelte
Viewer has unused export property 'funky'. If it is for external reference only, please consider using `export const funky`
   export let injectedJS = "";
   export let injectedCSS = "";
   export let funky = false;
                 ^
   let iframe;
```