### PR TITLE
Docs - fixes to code examples

### DIFF
--- a/packages/site/src/routes/_docs.svtext
+++ b/packages/site/src/routes/_docs.svtext
@@ -124,7 +124,7 @@ It supports all of the same options as the preprocessor although the function si
 ```js
 import { compile } from 'mdsvex';
 
-const transformed_code = compile(`
+const transformed_code = await compile(`
 <script>
   import Chart from './Chart.svelte';
 </script>

--- a/packages/site/src/routes/_docs.svtext
+++ b/packages/site/src/routes/_docs.svtext
@@ -98,7 +98,7 @@ If you want to use mdsvex without a bundler because you are your own person, the
 
 ```js
 const svelte = require('svelte/compiler');
-const { mdsvex } = require(mdsvex);
+const { mdsvex } = require('mdsvex');
 
 // This will give you a valid svelte component
 const preprocessed = await svelte.preprocess(


### PR DESCRIPTION
The code examples makes it look like `compile` is synchronous, so I suggest adding the `await` keyword to it to match the `preprocess` example. Also spotted a little error with missing quotes in a require statement.