### PR TITLE
Fixes playground docs for `metadata`

### DIFF
--- a/packages/site/src/routes/_source.js
+++ b/packages/site/src/routes/_source.js
@@ -51,7 +51,7 @@ Yeah, thats right you can put wigdets in markdown (\`.svx\` files or otherwise).
 </Seriously>
 
 Sometimes you need your widgets **inlined** (like this:<Count count="{number}"/>) because why shouldn't you.
-Obviously you have access to values defined in YAML (namespaced under \`_metadata\`) and anything defined in an fenced \`js exec\` block can be referenced directly.
+Obviously you have access to values defined in YAML (namespaced under \`metadata\`) and anything defined in an fenced \`js exec\` block can be referenced directly.
 
 Normal markdown stuff works too:
 


### PR DESCRIPTION
One character fix on the playground.

Looks like `metadata` was renamed for https://github.com/pngwn/MDsveX/issues/25, this fixes the playground referencing the old name.