### PR TITLE
Handle no options gracefully in compile

### DIFF
--- a/.changeset/violet-meals-reply.md
+++ b/.changeset/violet-meals-reply.md
@@ -1,0 +1,5 @@
+---
+'mdsvex': patch
+---
+
+Fix calling mdsvex.compile with no options

--- a/packages/mdsvex/src/index.ts
+++ b/packages/mdsvex/src/index.ts
@@ -313,7 +313,10 @@ const _compile = (
 		content: source,
 		filename:
 			(opts && opts.filename) ||
-			`file${(opts && (opts.extensions && opts.extensions[0]) || opts.extension) || '.svx'}`,
+			`file${
+				(opts && ((opts.extensions && opts.extensions[0]) || opts.extension)) ||
+				'.svx'
+			}`,
 	});
 
 export { _compile as compile };

--- a/packages/mdsvex/test/it/mdsvex.test.ts
+++ b/packages/mdsvex/test/it/mdsvex.test.ts
@@ -1066,6 +1066,17 @@ I am some paragraph text
 	);
 });
 
+mdsvex_it('compile, no options', async () => {
+	const output = await compile('# Hello world');
+	assert.equal(
+		{
+			code: '\n<h1>Hello world</h1>\n',
+			map: '',
+		},
+		output
+	);
+});
+
 mdsvex_it('layout: allow custom components', async () => {
 	const output = await compile(
 		`


### PR DESCRIPTION
Ran into this when trying to wrangle mdsvex for a small prototype I'm working on. Basically this chunk doesn't work as-is (I think the intention was that it should):

```js
require("svelte/package.json"); // svelte is a peer dependency. 
var mdsvex = require("mdsvex")
mdsvex.compile("# Hello, world\nHi")
```

https://runkit.com/embed/h4ze1371hmyq