### PR TITLE
Silence spurious compile warnings

### DIFF
--- a/.changeset/moody-carpets-switch.md
+++ b/.changeset/moody-carpets-switch.md
@@ -1,0 +1,5 @@
+---
+'mdsvex': patch
+---
+
+Various small fixes to compile typechecking

--- a/.changeset/violet-meals-reply.md
+++ b/.changeset/violet-meals-reply.md
@@ -1,0 +1,5 @@
+---
+'mdsvex': patch
+---
+
+Fix calling mdsvex.compile with no options

--- a/packages/mdsvex/src/index.ts
+++ b/packages/mdsvex/src/index.ts
@@ -229,6 +229,7 @@ export const mdsvex = (options: MdsvexOptions = defaults): Preprocessor => {
 
 	const unknown_opts = [];
 	const known_opts = [
+		'filename',
 		'remarkPlugins',
 		'rehypePlugins',
 		'smartypants',
@@ -294,7 +295,7 @@ export const mdsvex = (options: MdsvexOptions = defaults): Preprocessor => {
  * - **source** - the source code to convert.
  * - **options** - An options object with the following properties, all are optional.
  *
- *
+ * - `filename` - The filename of the generated file
  * - `extension` - The extension to use for mdsvex files
  * - `extensions` - The extensions to use for mdsvex files
  * - `layout` - Layouts to apply to mdsvex documents
@@ -307,7 +308,7 @@ export const mdsvex = (options: MdsvexOptions = defaults): Preprocessor => {
 
 const _compile = (
 	source: string,
-	opts: MdsvexCompileOptions
+	opts?: MdsvexCompileOptions
 ): PreprocessorReturn =>
 	mdsvex(opts).markup({
 		content: source,

--- a/packages/mdsvex/src/index.ts
+++ b/packages/mdsvex/src/index.ts
@@ -313,7 +313,10 @@ const _compile = (
 		content: source,
 		filename:
 			(opts && opts.filename) ||
-			`file${(opts && (opts.extensions && opts.extensions[0]) || opts.extension) || '.svx'}`,
+			`file${
+				(opts && ((opts.extensions && opts.extensions[0]) || opts.extension)) ||
+				'.svx'
+			}`,
 	});
 
 export { _compile as compile };

--- a/packages/mdsvex/test/it/mdsvex.test.ts
+++ b/packages/mdsvex/test/it/mdsvex.test.ts
@@ -764,7 +764,7 @@ number: 999
 
 	assert.equal(
 		warning,
-		'mdsvex: Received unknown options: bip, bop, boom. Valid options are: remarkPlugins, rehypePlugins, smartypants, extension, extensions, layout, highlight, frontmatter.'
+		'mdsvex: Received unknown options: bip, bop, boom. Valid options are: filename, remarkPlugins, rehypePlugins, smartypants, extension, extensions, layout, highlight, frontmatter.'
 	);
 
 	console.warn = console_warn;

--- a/packages/mdsvex/test/it/mdsvex.test.ts
+++ b/packages/mdsvex/test/it/mdsvex.test.ts
@@ -1066,6 +1066,17 @@ I am some paragraph text
 	);
 });
 
+mdsvex_it('compile, no options', async () => {
+	const output = await compile('# Hello world');
+	assert.equal(
+		{
+			code: '\n<h1>Hello world</h1>\n',
+			map: '',
+		},
+		output
+	);
+});
+
 mdsvex_it('layout: allow custom components', async () => {
 	const output = await compile(
 		`


### PR DESCRIPTION
This builds on changes in #185, which should be merged first.