### PR TITLE
Change plugin order

### DIFF
--- a/.changeset/orange-scissors-push.md
+++ b/.changeset/orange-scissors-push.md
@@ -1,0 +1,5 @@
+---
+'mdsvex': minor
+---
+
+User-provided remark plugins that modify code nodes now run before the builtin in code highlighting, allowing for custom code transformations.

--- a/packages/mdsvex/package.json
+++ b/packages/mdsvex/package.json
@@ -37,6 +37,7 @@
 		"front-matter": "^4.0.0",
 		"js-yaml": "^3.13.1",
 		"node-fetch": "^2.6.0",
+		"rehype-shiki": "^0.0.9",
 		"rehype-slug": "^3.0.0",
 		"rehype-toc": "^3.0.1",
 		"remark-autolink-headings": "^6.0.0",

--- a/packages/mdsvex/package.json
+++ b/packages/mdsvex/package.json
@@ -37,7 +37,6 @@
 		"front-matter": "^4.0.0",
 		"js-yaml": "^3.13.1",
 		"node-fetch": "^2.6.0",
-		"rehype-shiki": "^0.0.9",
 		"rehype-slug": "^3.0.0",
 		"rehype-toc": "^3.0.1",
 		"remark-autolink-headings": "^6.0.0",

--- a/packages/mdsvex/src/index.ts
+++ b/packages/mdsvex/src/index.ts
@@ -77,8 +77,7 @@ export function transform(
 		.use(external, { target: false, rel: ['nofollow'] })
 		.use(escape_code, { blocks: !!highlight })
 		.use(extract_frontmatter, [{ type: fm_opts.type, marker: fm_opts.marker }])
-		.use(parse_frontmatter, { parse: fm_opts.parse, type: fm_opts.type })
-		.use(highlight_blocks, highlight || {});
+		.use(parse_frontmatter, { parse: fm_opts.parse, type: fm_opts.type });
 
 	if (smartypants) {
 		toMDAST.use(
@@ -87,7 +86,7 @@ export function transform(
 		);
 	}
 
-	apply_plugins(remarkPlugins, toMDAST);
+	apply_plugins(remarkPlugins, toMDAST).use(highlight_blocks, highlight || {});
 
 	const toHAST = toMDAST
 		.use(remark2rehype, {
@@ -280,7 +279,9 @@ export const mdsvex = (options: MdsvexOptions = defaults): Preprocessor => {
 
 	return {
 		markup: async ({ content, filename }) => {
-			const extensionsParts = (extensions || [extension]).map(ext => ext.split('.').pop());
+			const extensionsParts = (extensions || [extension]).map((ext) =>
+				ext.split('.').pop()
+			);
 			if (!extensionsParts.includes(filename.split('.').pop())) return;
 
 			const parsed = await parser.process({ contents: content, filename });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,6 +58,7 @@ importers:
       front-matter: 4.0.2
       js-yaml: 3.14.0
       node-fetch: 2.6.0
+      rehype-shiki: 0.0.9
       rehype-slug: 3.0.0
       rehype-toc: 3.0.2
       remark-autolink-headings: 6.0.1
@@ -96,6 +97,7 @@ importers:
       js-yaml: ^3.13.1
       node-fetch: ^2.6.0
       prismjs: ^1.17.1
+      rehype-shiki: ^0.0.9
       rehype-slug: ^3.0.0
       rehype-toc: ^3.0.1
       remark-autolink-headings: ^6.0.0
@@ -196,19 +198,19 @@ importers:
       '@types/unist': ^2.0.3
   packages/svast-stringify:
     dependencies:
-      svast: 'link:../svast'
+      svast: link:../svast
     specifiers:
-      svast: 'workspace:^0.2.0'
+      svast: workspace:^0.2.0
   packages/svast-utils:
     dependencies:
-      svast: 'link:../svast'
+      svast: link:../svast
     specifiers:
-      svast: 'workspace:^0.2.0'
+      svast: workspace:^0.2.0
   packages/svelte-parse:
     dependencies:
-      svast: 'link:../svast'
+      svast: link:../svast
     specifiers:
-      svast: 'workspace:^0.2.0'
+      svast: workspace:^0.2.0
 lockfileVersion: 5.2
 packages:
   /@arr/every/1.0.1:
@@ -3749,6 +3751,15 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==
+  /json5/2.2.0:
+    dependencies:
+      minimist: 1.2.5
+    dev: true
+    engines:
+      node: '>=6'
+    hasBin: true
+    resolution:
+      integrity: sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==
   /jsonfile/4.0.0:
     dev: true
     optionalDependencies:
@@ -3967,6 +3978,12 @@ packages:
     dev: true
     resolution:
       integrity: sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==
+  /lru-cache/5.1.1:
+    dependencies:
+      yallist: 3.1.1
+    dev: true
+    resolution:
+      integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
   /ltgt/2.2.1:
     dev: true
     resolution:
@@ -4368,6 +4385,12 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
+  /onigasm/2.2.5:
+    dependencies:
+      lru-cache: 5.1.1
+    dev: true
+    resolution:
+      integrity: sha512-F+th54mPc0l1lp1ZcFMyL/jTs2Tlq4SqIHKIXGZOR/VkHkF9A7Fr5rRr5+ZG/lWeRsyrClLYRq7s/yFQ/XhWCA==
   /optionator/0.8.3:
     dependencies:
       deep-is: 0.1.3
@@ -4943,6 +4966,16 @@ packages:
     dev: true
     resolution:
       integrity: sha512-gxG72uj8wV2WnjlanTu5qxV5xqLkI3H1q8HSWbof7fHa12FuT+X3fGj275KwxgXESi8hJvHtZiDUwcZ9rjcHRg==
+  /rehype-shiki/0.0.9:
+    dependencies:
+      hast-util-to-string: 1.0.4
+      shiki: 0.1.7
+      shiki-languages: 0.1.6
+      unist-builder: 2.0.3
+      unist-util-visit: 2.0.3
+    dev: true
+    resolution:
+      integrity: sha512-jyatOsBu0A8ZUnQig0QK0xq7CFZpeEukr0DZazg/zFLZATbdcbnIlO779pIW2El/C2S5An33sN2d4w2kmdS+Bw==
   /rehype-slug/2.0.3:
     dependencies:
       github-slugger: 1.3.0
@@ -5461,6 +5494,38 @@ packages:
     dev: true
     resolution:
       integrity: sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==
+  /shiki-languages/0.1.6:
+    dependencies:
+      vscode-textmate: github.com/octref/vscode-textmate/e65aabe2227febda7beaad31dd0fca1228c5ddf3
+    dev: true
+    resolution:
+      integrity: sha512-rMu+z97UCPKMtPBkzLBItReawXnlOgXZmELFwI/s3ATxd9VzJgSQTtQW/hmW5EYCrzF2kAUjoOnn+50/MPWjgQ==
+  /shiki-languages/0.1.6_onigasm@2.2.5:
+    dependencies:
+      vscode-textmate: github.com/octref/vscode-textmate/e65aabe2227febda7beaad31dd0fca1228c5ddf3_onigasm@2.2.5
+    dev: true
+    peerDependencies:
+      onigasm: '*'
+    resolution:
+      integrity: sha512-rMu+z97UCPKMtPBkzLBItReawXnlOgXZmELFwI/s3ATxd9VzJgSQTtQW/hmW5EYCrzF2kAUjoOnn+50/MPWjgQ==
+  /shiki-themes/0.1.7_onigasm@2.2.5:
+    dependencies:
+      json5: 2.2.0
+      vscode-textmate: github.com/octref/vscode-textmate/e65aabe2227febda7beaad31dd0fca1228c5ddf3_onigasm@2.2.5
+    dev: true
+    peerDependencies:
+      onigasm: '*'
+    resolution:
+      integrity: sha512-mpF/VynGun/uNdjOIPnyPv4boN/QYDh+zE94SavgvmatMHkXXjZhls19Xv9rcRwuxUrWfXjaPkEZj7VAk94GGg==
+  /shiki/0.1.7:
+    dependencies:
+      onigasm: 2.2.5
+      shiki-languages: 0.1.6_onigasm@2.2.5
+      shiki-themes: 0.1.7_onigasm@2.2.5
+      vscode-textmate: github.com/octref/vscode-textmate/e65aabe2227febda7beaad31dd0fca1228c5ddf3_onigasm@2.2.5
+    dev: true
+    resolution:
+      integrity: sha512-9J0PhAdXv6tt3FZf82oKZkcV8c8NRZYJEOH0eIrrxfcyNzMuB79tJFGFSI3OhhiYFL5namob/Ii0Ri4iDoF15A==
   /shimport/1.0.1:
     dev: true
     resolution:
@@ -6097,10 +6162,10 @@ packages:
     dev: true
     resolution:
       integrity: sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A==
-  /unist-util-is/4.0.2:
+  /unist-util-is/4.1.0:
     dev: true
     resolution:
-      integrity: sha512-Ofx8uf6haexJwI1gxWMGg6I/dLnF2yE+KibhD3/diOqY2TinLcqHXCV6OI5gFVn3xQqDH+u0M625pfKwIwgBKQ==
+      integrity: sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg==
   /unist-util-modify-children/1.1.6:
     dependencies:
       array-iterate: 1.1.4
@@ -6132,13 +6197,13 @@ packages:
     dev: true
     resolution:
       integrity: sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==
-  /unist-util-visit-parents/3.1.0:
+  /unist-util-visit-parents/3.1.1:
     dependencies:
       '@types/unist': 2.0.3
-      unist-util-is: 4.0.2
+      unist-util-is: 4.1.0
     dev: true
     resolution:
-      integrity: sha512-0g4wbluTF93npyPrp/ymd3tCDTMnP0yo2akFD2FIBAYXq/Sga3lwaU1D8OYKbtpioaI6CkDcQ6fsMnmtzt7htw==
+      integrity: sha512-1KROIZWo6bcMrZEwiH2UrXDyalAa0uqzWCxCJj6lPOvTve2WkfgCytoDTPaMnodXh1WrXOq0haVYHj99ynJlsg==
   /unist-util-visit/1.4.1:
     dependencies:
       unist-util-visit-parents: 2.1.2
@@ -6148,8 +6213,8 @@ packages:
   /unist-util-visit/2.0.3:
     dependencies:
       '@types/unist': 2.0.3
-      unist-util-is: 4.0.2
-      unist-util-visit-parents: 3.1.0
+      unist-util-is: 4.1.0
+      unist-util-visit-parents: 3.1.1
     dev: true
     resolution:
       integrity: sha512-iJ4/RczbJMkD0712mGktuGpm/U4By4FfDonL7N/9tATGIF4imikjOuagyMY53tnZq3NP6BcmlrHhEKAfGWjh7Q==
@@ -6356,6 +6421,10 @@ packages:
     dev: true
     resolution:
       integrity: sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=
+  /yallist/3.1.1:
+    dev: true
+    resolution:
+      integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
   /yargs-parser/10.1.0:
     dependencies:
       camelcase: 4.1.0
@@ -6399,3 +6468,24 @@ packages:
     dev: false
     resolution:
       integrity: sha512-GvGLuJ7XHJPGEUQ52vh8fh+vPjfikuGcu7yBswfrsNsHqnAoytOVuSb69eM0j8wQIjMz0U3kY3YsfwMhJgfG9w==
+  github.com/octref/vscode-textmate/e65aabe2227febda7beaad31dd0fca1228c5ddf3:
+    dev: true
+    name: vscode-textmate
+    peerDependencies:
+      onigasm: ^2.1.0
+      oniguruma: ^7.0.0
+    resolution:
+      tarball: https://codeload.github.com/octref/vscode-textmate/tar.gz/e65aabe2227febda7beaad31dd0fca1228c5ddf3
+    version: 4.0.1
+  github.com/octref/vscode-textmate/e65aabe2227febda7beaad31dd0fca1228c5ddf3_onigasm@2.2.5:
+    dependencies:
+      onigasm: 2.2.5
+    dev: true
+    id: github.com/octref/vscode-textmate/e65aabe2227febda7beaad31dd0fca1228c5ddf3
+    name: vscode-textmate
+    peerDependencies:
+      onigasm: ^2.1.0
+      oniguruma: ^7.0.0
+    resolution:
+      tarball: https://codeload.github.com/octref/vscode-textmate/tar.gz/e65aabe2227febda7beaad31dd0fca1228c5ddf3
+    version: 4.0.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,7 +58,6 @@ importers:
       front-matter: 4.0.2
       js-yaml: 3.14.0
       node-fetch: 2.6.0
-      rehype-shiki: 0.0.9
       rehype-slug: 3.0.0
       rehype-toc: 3.0.2
       remark-autolink-headings: 6.0.1
@@ -97,7 +96,6 @@ importers:
       js-yaml: ^3.13.1
       node-fetch: ^2.6.0
       prismjs: ^1.17.1
-      rehype-shiki: ^0.0.9
       rehype-slug: ^3.0.0
       rehype-toc: ^3.0.1
       remark-autolink-headings: ^6.0.0
@@ -3751,15 +3749,6 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==
-  /json5/2.2.0:
-    dependencies:
-      minimist: 1.2.5
-    dev: true
-    engines:
-      node: '>=6'
-    hasBin: true
-    resolution:
-      integrity: sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==
   /jsonfile/4.0.0:
     dev: true
     optionalDependencies:
@@ -3978,12 +3967,6 @@ packages:
     dev: true
     resolution:
       integrity: sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==
-  /lru-cache/5.1.1:
-    dependencies:
-      yallist: 3.1.1
-    dev: true
-    resolution:
-      integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
   /ltgt/2.2.1:
     dev: true
     resolution:
@@ -4385,12 +4368,6 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
-  /onigasm/2.2.5:
-    dependencies:
-      lru-cache: 5.1.1
-    dev: true
-    resolution:
-      integrity: sha512-F+th54mPc0l1lp1ZcFMyL/jTs2Tlq4SqIHKIXGZOR/VkHkF9A7Fr5rRr5+ZG/lWeRsyrClLYRq7s/yFQ/XhWCA==
   /optionator/0.8.3:
     dependencies:
       deep-is: 0.1.3
@@ -4966,16 +4943,6 @@ packages:
     dev: true
     resolution:
       integrity: sha512-gxG72uj8wV2WnjlanTu5qxV5xqLkI3H1q8HSWbof7fHa12FuT+X3fGj275KwxgXESi8hJvHtZiDUwcZ9rjcHRg==
-  /rehype-shiki/0.0.9:
-    dependencies:
-      hast-util-to-string: 1.0.4
-      shiki: 0.1.7
-      shiki-languages: 0.1.6
-      unist-builder: 2.0.3
-      unist-util-visit: 2.0.3
-    dev: true
-    resolution:
-      integrity: sha512-jyatOsBu0A8ZUnQig0QK0xq7CFZpeEukr0DZazg/zFLZATbdcbnIlO779pIW2El/C2S5An33sN2d4w2kmdS+Bw==
   /rehype-slug/2.0.3:
     dependencies:
       github-slugger: 1.3.0
@@ -5494,38 +5461,6 @@ packages:
     dev: true
     resolution:
       integrity: sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==
-  /shiki-languages/0.1.6:
-    dependencies:
-      vscode-textmate: github.com/octref/vscode-textmate/e65aabe2227febda7beaad31dd0fca1228c5ddf3
-    dev: true
-    resolution:
-      integrity: sha512-rMu+z97UCPKMtPBkzLBItReawXnlOgXZmELFwI/s3ATxd9VzJgSQTtQW/hmW5EYCrzF2kAUjoOnn+50/MPWjgQ==
-  /shiki-languages/0.1.6_onigasm@2.2.5:
-    dependencies:
-      vscode-textmate: github.com/octref/vscode-textmate/e65aabe2227febda7beaad31dd0fca1228c5ddf3_onigasm@2.2.5
-    dev: true
-    peerDependencies:
-      onigasm: '*'
-    resolution:
-      integrity: sha512-rMu+z97UCPKMtPBkzLBItReawXnlOgXZmELFwI/s3ATxd9VzJgSQTtQW/hmW5EYCrzF2kAUjoOnn+50/MPWjgQ==
-  /shiki-themes/0.1.7_onigasm@2.2.5:
-    dependencies:
-      json5: 2.2.0
-      vscode-textmate: github.com/octref/vscode-textmate/e65aabe2227febda7beaad31dd0fca1228c5ddf3_onigasm@2.2.5
-    dev: true
-    peerDependencies:
-      onigasm: '*'
-    resolution:
-      integrity: sha512-mpF/VynGun/uNdjOIPnyPv4boN/QYDh+zE94SavgvmatMHkXXjZhls19Xv9rcRwuxUrWfXjaPkEZj7VAk94GGg==
-  /shiki/0.1.7:
-    dependencies:
-      onigasm: 2.2.5
-      shiki-languages: 0.1.6_onigasm@2.2.5
-      shiki-themes: 0.1.7_onigasm@2.2.5
-      vscode-textmate: github.com/octref/vscode-textmate/e65aabe2227febda7beaad31dd0fca1228c5ddf3_onigasm@2.2.5
-    dev: true
-    resolution:
-      integrity: sha512-9J0PhAdXv6tt3FZf82oKZkcV8c8NRZYJEOH0eIrrxfcyNzMuB79tJFGFSI3OhhiYFL5namob/Ii0Ri4iDoF15A==
   /shimport/1.0.1:
     dev: true
     resolution:
@@ -6421,10 +6356,6 @@ packages:
     dev: true
     resolution:
       integrity: sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=
-  /yallist/3.1.1:
-    dev: true
-    resolution:
-      integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
   /yargs-parser/10.1.0:
     dependencies:
       camelcase: 4.1.0
@@ -6468,24 +6399,3 @@ packages:
     dev: false
     resolution:
       integrity: sha512-GvGLuJ7XHJPGEUQ52vh8fh+vPjfikuGcu7yBswfrsNsHqnAoytOVuSb69eM0j8wQIjMz0U3kY3YsfwMhJgfG9w==
-  github.com/octref/vscode-textmate/e65aabe2227febda7beaad31dd0fca1228c5ddf3:
-    dev: true
-    name: vscode-textmate
-    peerDependencies:
-      onigasm: ^2.1.0
-      oniguruma: ^7.0.0
-    resolution:
-      tarball: https://codeload.github.com/octref/vscode-textmate/tar.gz/e65aabe2227febda7beaad31dd0fca1228c5ddf3
-    version: 4.0.1
-  github.com/octref/vscode-textmate/e65aabe2227febda7beaad31dd0fca1228c5ddf3_onigasm@2.2.5:
-    dependencies:
-      onigasm: 2.2.5
-    dev: true
-    id: github.com/octref/vscode-textmate/e65aabe2227febda7beaad31dd0fca1228c5ddf3
-    name: vscode-textmate
-    peerDependencies:
-      onigasm: ^2.1.0
-      oniguruma: ^7.0.0
-    resolution:
-      tarball: https://codeload.github.com/octref/vscode-textmate/tar.gz/e65aabe2227febda7beaad31dd0fca1228c5ddf3
-    version: 4.0.1


### PR DESCRIPTION
This PR changes the current plugin order for remark plugins, running builtin in code highlighting after all user-provided plugins have run.

Fixes: #93

