### PR TITLE
Standalone `compile()` function now returns headmatter data too.

### DIFF
--- a/.changeset/tiny-pants-love.md
+++ b/.changeset/tiny-pants-love.md
@@ -1,0 +1,5 @@
+---
+'mdsvex': patch
+---
+
+Standalone compile() function not returning headmatter attributes. Also export all types.

--- a/packages/mdsvex/src/index.ts
+++ b/packages/mdsvex/src/index.ts
@@ -12,6 +12,7 @@ import type {
 	UnifiedPlugins,
 	LayoutMode,
 } from './types';
+export * from './types';
 
 import { join } from 'path';
 import fs from 'fs';
@@ -285,7 +286,11 @@ export const mdsvex = (options: MdsvexOptions = defaults): Preprocessor => {
 			if (!extensionsParts.includes(filename.split('.').pop())) return;
 
 			const parsed = await parser.process({ contents: content, filename });
-			return { code: parsed.contents as string, map: '' };
+			return {
+				code: parsed.contents as string,
+				data: parsed.data as Record<string, unknown>,
+				map: '',
+			};
 		},
 	};
 };

--- a/packages/mdsvex/src/types.ts
+++ b/packages/mdsvex/src/types.ts
@@ -298,9 +298,11 @@ export interface MdsvexCompileOptions extends MdsvexOptions {
 	filename?: string;
 }
 
-export type PreprocessorReturn = Promise<
-	{ code: string; map?: string } | undefined
->;
+export type PreprocessorReturn = Promise<{
+	code: string;
+	data?: Record<string, unknown>;
+	map?: string
+} | undefined>;
 
 export interface Preprocessor {
 	markup: (args: { content: string; filename: string }) => PreprocessorReturn;

--- a/packages/mdsvex/test/it/mdsvex.test.ts
+++ b/packages/mdsvex/test/it/mdsvex.test.ts
@@ -1105,6 +1105,32 @@ mdsvex_it('compile, no options', async () => {
 	assert.equal(
 		{
 			code: '\n<h1>Hello world</h1>\n',
+			data: {},
+			map: '',
+		},
+		output
+	);
+});
+
+mdsvex_it('compile, gets headmatter attributes', async () => {
+	const output = await compile(
+		`
+---
+title: Yo
+---
+
+# Hello world
+`
+	);
+
+	assert.equal(
+		{
+			code: '<script context=\"module\">\n\texport const metadata = {\"title\":\"Yo\"};\n\tconst { title } = metadata;\n</script>\n\n<h1>Hello world</h1>\n',
+			data: {
+				fm: {
+					title: 'Yo'
+				},
+			},
 			map: '',
 		},
 		output


### PR DESCRIPTION
Standalone `compile()` function now returns headmatter data too.
Export all types in case others want to use them.
Added tests, and all tests passing.
I added the `changeset` thing, not sure what I'm doing there. :)