### PR TITLE
Escape code chunks in browser builds

### DIFF
--- a/.changeset/forty-bananas-fly.md
+++ b/.changeset/forty-bananas-fly.md
@@ -1,0 +1,5 @@
+---
+'mdsvex': patch
+---
+
+Escape code chunks in browser builds

--- a/packages/mdsvex/src/transformers/index.ts
+++ b/packages/mdsvex/src/transformers/index.ts
@@ -554,7 +554,7 @@ export function highlight_blocks({
 	}
 
 	return async function (tree) {
-		if (highlight_fn && !(process as RollupProcess).browser) {
+		if (highlight_fn) {
 			const nodes: (Code | HTML)[] = [];
 			visit<Code>(tree, 'code', (node) => {
 				nodes.push(node);


### PR DESCRIPTION
Do this by allowing the highlighting function to go through in browser
build -- it won't highlight, but it will escape.