### PR TITLE
feat(mdsvex): pass metastring to custom highlight functions

### DIFF
--- a/.changeset/modern-beds-drive.md
+++ b/.changeset/modern-beds-drive.md
@@ -1,0 +1,5 @@
+---
+'mdsvex': patch
+---
+
+Custom highlight functions now receive the metastring as an additional argument.

--- a/packages/mdsvex/src/transformers/index.ts
+++ b/packages/mdsvex/src/transformers/index.ts
@@ -412,7 +412,7 @@ export function transform_hast({
 					type: 'raw',
 					value: import_script
 						? `<Layout_MDSVEX_DEFAULT {...$$props}${
-								fm ? ' {...metadata}' : ''
+							fm ? ' {...metadata}' : ''
 						  }>`
 						: '',
 				},

--- a/packages/mdsvex/src/transformers/index.ts
+++ b/packages/mdsvex/src/transformers/index.ts
@@ -173,11 +173,9 @@ function extract_parts(nodes: Array<Element | Text>): Parts {
 		// svelte special tags that have to be top level
 		if (!result.html || !result.html.children) return parts;
 
-		const _parts: Array<[
-			'html' | 'css' | 'special' | 'instance' | 'module',
-			number,
-			number
-		]> = result.html.children.map((v) => {
+		const _parts: Array<
+			['html' | 'css' | 'special' | 'instance' | 'module', number, number]
+		> = result.html.children.map((v) => {
 			if (
 				v.type === 'Options' ||
 				v.type === 'Head' ||
@@ -414,8 +412,8 @@ export function transform_hast({
 					type: 'raw',
 					value: import_script
 						? `<Layout_MDSVEX_DEFAULT {...$$props}${
-							fm ? ' {...metadata}' : ''
-						}>`
+								fm ? ' {...metadata}' : ''
+						  }>`
 						: '',
 				},
 				//@ts-ignore
@@ -563,7 +561,11 @@ export function highlight_blocks({
 			await Promise.all(
 				nodes.map(async (node) => {
 					(node as HTML).type = 'html';
-					node.value = await highlight_fn(node.value, (node as Code).lang);
+					node.value = await highlight_fn(
+						node.value,
+						(node as Code).lang,
+						(node as Code).meta
+					);
 				})
 			);
 		}

--- a/packages/mdsvex/src/types.ts
+++ b/packages/mdsvex/src/types.ts
@@ -152,7 +152,8 @@ export type Layout = Record<string, LayoutMeta>;
 
 export type Highlighter = (
 	code: string,
-	lang: string | undefined
+	lang: string | undefined,
+	metastring: string | undefined
 ) => string | Promise<string>;
 interface HighlightOptions {
 	/**
@@ -298,11 +299,14 @@ export interface MdsvexCompileOptions extends MdsvexOptions {
 	filename?: string;
 }
 
-export type PreprocessorReturn = Promise<{
-	code: string;
-	data?: Record<string, unknown>;
-	map?: string
-} | undefined>;
+export type PreprocessorReturn = Promise<
+	| {
+			code: string;
+			data?: Record<string, unknown>;
+			map?: string;
+	  }
+	| undefined
+>;
 
 export interface Preprocessor {
 	markup: (args: { content: string; filename: string }) => PreprocessorReturn;

--- a/packages/mdsvex/test/it/code_highlighting.test.ts
+++ b/packages/mdsvex/test/it/code_highlighting.test.ts
@@ -185,6 +185,34 @@ i am some code
 	}
 );
 
+highlight('Custom highlight functions receive the metastring', async () => {
+	function _highlight(
+		code: string,
+		lang: string | undefined,
+		meta: string | undefined
+	): string {
+		return `<code class="${lang}-${meta}">${code}</code>`;
+	}
+
+	const output = await mdsvex({
+		highlight: { highlighter: _highlight },
+	}).markup({
+		content: `
+\`\`\`somecode hello-friends what are you
+i am some code
+\`\`\`
+    `,
+		filename: 'thing.svx',
+	});
+
+	assert.equal(
+		lines(
+			`<code class="somecode-hello-friends what are you">i am some code</code>`
+		),
+		output && lines(output.code)
+	);
+});
+
 highlight(
 	'Should be possible to pass an async custom highlight function ',
 	async () => {


### PR DESCRIPTION
Pass metastring to custom highlight functions. Closes #146.