### PR TITLE
fix typos in docs

### DIFF
--- a/packages/site/src/routes/_docs.svtext
+++ b/packages/site/src/routes/_docs.svtext
@@ -414,7 +414,7 @@ frontmatter: { parse: Function, marker: string };
 
 By default mdsvex supports yaml frontmatter, this is defined by enclosing the YAML in three hyphens (`---`). If you want to use a custom language or marker for frontmatter then you can use the `frontmatter` option.
 
-`frontmatter` should be an object that can receive a `marker` and a `parse` property.
+`frontmatter` should be an object that can contain a `marker` and a `parse` property.
 
 ```sig
 marker: string = '-';


### PR DESCRIPTION
While reviewing the documentation I encountered a few typographical issues. 
It is mostly a matter of having a word mispelled, with the biggest change being on line 417.

```diff
- `frontmatter` should be an object that can be a passed a `marker` and a `parse` property.
+ `frontmatter` should be an object that can be receive a `marker` and a `parse` property.
```

I felt the sentence "can be passed a marker", obtained by removing the unnecessary word, was overly complicated.