### PR TITLE
Copy CodeMirror changes from upstream for SvelteKit support

### DIFF
--- a/packages/site/src/components/Repl/CodeMirror.svelte
+++ b/packages/site/src/components/Repl/CodeMirror.svelte
@@ -1,19 +1,5 @@
-<script context="module">
-  import { is_browser } from "./env.js";
-
-  let codemirror_promise;
-  let _CodeMirror;
-
-  if (is_browser) {
-    codemirror_promise = import("./codemirror.js");
-
-    codemirror_promise.then(mod => {
-      _CodeMirror = mod.default;
-    });
-  }
-</script>
-
-<script>
+[<script>
+  import './codemirror.css';
   import { onMount, createEventDispatcher } from "svelte";
   import Message from "./Message.svelte";
 
@@ -126,18 +112,16 @@
     }
   }
 
-  onMount(() => {
-    if (_CodeMirror) {
-      CodeMirror = _CodeMirror;
+  onMount(async () => {
+    if (CodeMirror) {
       createEditor(mode || "svelte").then(() => {
         if (editor) editor.setValue(code || "");
       });
     } else {
-      codemirror_promise.then(async mod => {
-        CodeMirror = mod.default;
-        await createEditor(mode || "svelte");
-        if (editor) editor.setValue(code || "");
-      });
+      let mod = await import('./codemirror.js');
+      CodeMirror = mod.default;
+      await createEditor(mode || "svelte");
+      if (editor) editor.setValue(code || "");
     }
 
     return () => {


### PR DESCRIPTION
This was done upstream in https://github.com/sveltejs/svelte-repl/commit/729cd86b131329d0118676cabc0e45a054798b10 and would be needed if we want to run the site on SvelteKit (https://github.com/pngwn/MDsveX/issues/317)