### PR TITLE
defineMDSveXConfig

### DIFF
--- a/.changeset/modern-bears-pull.md
+++ b/.changeset/modern-bears-pull.md
@@ -1,0 +1,5 @@
+---
+'mdsvex': patch
+---
+
+expose types, and defineMDSveXConfig

--- a/packages/mdsvex/package.json
+++ b/packages/mdsvex/package.json
@@ -7,8 +7,7 @@
 	"browser": "dist/mdsvex.js",
 	"repository": "https://github.com/pngwn/MDsveX",
 	"scripts": {
-		"build": "rollup -c",
-		"types": "dts-generator --project . --out dist/main.es.d.ts"
+		"build": "rollup -c"
 	},
 	"files": [
 		"dist/*",

--- a/packages/mdsvex/src/define-config.ts
+++ b/packages/mdsvex/src/define-config.ts
@@ -1,0 +1,3 @@
+import { MdsvexOptions } from './types';
+
+export const defineConfig = (config: MdsvexOptions) => config;

--- a/packages/mdsvex/src/main.ts
+++ b/packages/mdsvex/src/main.ts
@@ -1,4 +1,4 @@
-export { defineConfig as defineMDSvexConfig } from './define-config';
+export { defineConfig as defineMDSveXConfig } from './define-config';
 export { compile, mdsvex } from './index';
 export { escape_svelty as escapeSvelte } from './transformers';
 export type {

--- a/packages/mdsvex/src/main.ts
+++ b/packages/mdsvex/src/main.ts
@@ -1,2 +1,8 @@
-export { mdsvex, compile } from './index';
+export { defineConfig as defineMDSvexConfig } from './define-config';
+export { compile, mdsvex } from './index';
 export { escape_svelty as escapeSvelte } from './transformers';
+export type {
+	MdsvexCompileOptions,
+	MdsvexLanguage,
+	MdsvexOptions,
+} from './types';


### PR DESCRIPTION
Closes #300

For now I'm exporting the types starting from `MDSvex`, but I wonder if more types can be made public, like the SmartyPants one