### PR TITLE
fix SVAST Root type

### DIFF
--- a/packages/svast/index.d.ts
+++ b/packages/svast/index.d.ts
@@ -16,7 +16,7 @@ export interface SvelteParent extends Parent {
 	children: SvelteChild[];
 }
 
-export interface Root extends Parent {
+export interface Root extends SvelteParent {
 	type: 'root';
 }
 


### PR DESCRIPTION
Currently this code, the result of `parse({value: '<SomeComponent />', generatePositions: false})`:

```ts
const ast: Root = {
	type: 'root',
	children: [
		{
			type: 'svelteComponent',
			tagName: 'SomeComponent',
			properties: [],
			selfClosing: true,
			children: [],
		},
	],
};
```

results in this error:

```
(property) tagName: string
Type '{ type: string; tagName: string; properties: never[]; selfClosing: true; children: never[]; }'
is not assignable to type 'Node<Data>'.
  Object literal may only specify known properties, and 'tagName' does not exist in type 'Node<Data>'.ts(2322)
```

It can be fixed by changing `Root` to extend from `SvelteParent` instead of `Parent`.

I'm thinking this is correct, but if it needs to continue covering `Node` child types I can see a couple possibilities:

- `Root extends Parent` could be changed to `Root extends Parent<SvelteChild | Node>`
- `SvelteParent` could be changed from `children: SvelteChild[];` to `children: (SvelteChild | Node)[];`

Also, I'm wondering if line 86 `export interface Branch extends Parent {` needs the same fix?

Was thinking this is a good opportunity to make my first changeset, but not sure if this is just a patch or minor bump.

Thank you, it's been a pleasure working with this project!