### PR TITLE
Don't use wildcard import for layout component

### DIFF
--- a/packages/mdsvex/src/transformers/index.ts
+++ b/packages/mdsvex/src/transformers/index.ts
@@ -234,9 +234,11 @@ function generate_layout_import(
 ): string | false {
 	if (!layout) return false;
 
-	return `import Layout_MDSVEX_DEFAULT${
-		layout.components.length ? `, * as Components` : ''
-	} from '${layout.path}';`;
+	let result = `import Layout_MDSVEX_DEFAULT from '${layout.path}';`;
+	if (layout.components.length) {
+		result += `\nimport * as Components from '${layout.path}';`;
+	}
+	return result;
 }
 
 function generate_layout({

--- a/packages/mdsvex/src/types.ts
+++ b/packages/mdsvex/src/types.ts
@@ -152,8 +152,8 @@ export type Layout = Record<string, LayoutMeta>;
 
 export type Highlighter = (
 	code: string,
-	lang: string | undefined,
-	metastring: string | undefined
+	lang: string | null | undefined,
+	metastring: string | null | undefined
 ) => string | Promise<string>;
 interface HighlightOptions {
 	/**

--- a/packages/mdsvex/test/it/mdsvex.test.ts
+++ b/packages/mdsvex/test/it/mdsvex.test.ts
@@ -952,7 +952,10 @@ mdsvex_it('layout: allow custom components', async () => {
 </script>
 
 <script>
-	import Layout_MDSVEX_DEFAULT, * as Components from '${to_posix(
+	import Layout_MDSVEX_DEFAULT from '${to_posix(
+		join(fix_dir, 'LayoutWithComponents.svelte')
+	)}';
+	import * as Components from '${to_posix(
 		join(fix_dir, 'LayoutWithComponents.svelte')
 	)}';
 </script>
@@ -999,9 +1002,13 @@ hello *hello* **hello**
 </script>
 
 <script>
-	import Layout_MDSVEX_DEFAULT, * as Components from '${to_posix(
+	import Layout_MDSVEX_DEFAULT from '${to_posix(
 		join(fix_dir, 'LayoutThreeWithComponents.svelte')
 	)}';
+	import * as Components from '${to_posix(
+		join(fix_dir, 'LayoutThreeWithComponents.svelte')
+	)}';
+
 </script>
 
 <Layout_MDSVEX_DEFAULT {...$$props}>
@@ -1044,7 +1051,10 @@ I am some paragraph text
 </script>
 
 <script>
-	import Layout_MDSVEX_DEFAULT, * as Components from '${to_posix(
+	import Layout_MDSVEX_DEFAULT from '${to_posix(
+		join(fix_dir, 'LayoutTwoWithComponents.svelte')
+	)}';
+	import * as Components from '${to_posix(
 		join(fix_dir, 'LayoutTwoWithComponents.svelte')
 	)}';
 </script>
@@ -1086,7 +1096,10 @@ I am some paragraph text
 </script>
 
 <script>
-	import Layout_MDSVEX_DEFAULT, * as Components from '${to_posix(
+	import Layout_MDSVEX_DEFAULT from '${to_posix(
+		join(fix_dir, 'LayoutTwoWithComponents.svelte')
+	)}';
+	import * as Components from '${to_posix(
 		join(fix_dir, 'LayoutTwoWithComponents.svelte')
 	)}';
 </script>
@@ -1165,7 +1178,10 @@ I am some paragraph text
 </script>
 
 <script>
-	import Layout_MDSVEX_DEFAULT, * as Components from '${to_posix(
+	import Layout_MDSVEX_DEFAULT from '${to_posix(
+		join(fix_dir, 'LayoutTwoWithComponents.svelte')
+	)}';
+	import * as Components from '${to_posix(
 		join(fix_dir, 'LayoutTwoWithComponents.svelte')
 	)}';
 </script>
@@ -1207,7 +1223,10 @@ I am some paragraph text
 </script>
 
 <script>
-	import Layout_MDSVEX_DEFAULT, * as Components from '${to_posix(
+	import Layout_MDSVEX_DEFAULT from '${to_posix(
+		join(fix_dir, 'LayoutTwoWithComponents.svelte')
+	)}';
+	import * as Components from '${to_posix(
 		join(fix_dir, 'LayoutTwoWithComponents.svelte')
 	)}';
 </script>


### PR DESCRIPTION
After some experimentation with SvelteKit, I manage to reproduce the bug in #423. I guess SvelteKit cannot resolve the `load` function if the wildcard import is there. 

Unfortunately, I could not manage to link the manually built version of mdsvex with my SvelteKit project in order to test my changes. The error is as follow: 

```
Error while preprocessing xxx/index.svx - one$4 is not a function

TypeError: Error while preprocessing xxx/index.svx - one$4 is not a function
    at toHast (yyy/MDsveX/packages/mdsvex/dist/main.cjs.js:15354:14)
    at transformer (yyy/MDsveX/packages/mdsvex/dist/main.cjs.js:15402:12)
    at wrapped (yyy/MDsveX/packages/mdsvex/dist/main.cjs.js:204:19)
    at next (yyy/MDsveX/packages/mdsvex/dist/main.cjs.js:297:28)
    at done (yyy/MDsveX/packages/mdsvex/dist/main.cjs.js:234:16)
    at then (yyy/MDsveX/packages/mdsvex/dist/main.cjs.js:241:5)
```

@pngwn do you have any idea how I could solve this issue to allow me to test the patch correctly? 