### PR TITLE
Loosen extension filtering to cover more possibilities

### DIFF
--- a/.changeset/light-bikes-battle.md
+++ b/.changeset/light-bikes-battle.md
@@ -1,0 +1,5 @@
+---
+'mdsvex': patch
+---
+
+Allow more extensive extension filtering. For example, now `.md.svelte` is possible

--- a/packages/mdsvex/src/index.ts
+++ b/packages/mdsvex/src/index.ts
@@ -286,10 +286,8 @@ export const mdsvex = (options: MdsvexOptions = defaults): Preprocessor => {
 	return {
 		name: 'mdsvex',
 		markup: async ({ content, filename }) => {
-			const extensionsParts = (extensions || [extension]).map((ext) =>
-				ext.split('.').pop()
-			);
-			if (!extensionsParts.includes(filename.split('.').pop())) return;
+			const extensionsParts = (extensions || [extension]).map(ext => ext.startsWith('.') ? ext : '.' + ext);
+			if (!extensionsParts.some(ext => filename.endsWith(ext))) return;
 
 			const parsed = await parser.process({ contents: content, filename });
 			return {


### PR DESCRIPTION
Today, as of [mdsvex@0.11.0](https://github.com/pngwn/MDsveX/releases/tag/mdsvex%400.11.0), if `.md.svelte` is provided to the `extension` / `extensions` config, `MDsveX` will take it as `.svelte`, effectively making it process all `.svelte` files, which is not ideal.

This PR addresses this issue by making the mapping more relaxed (please see change).

The rationale for using `.md.svelte` is to take advantage of the default editor support for `.svelte` files, while still marking them as `markdown`-related.

---

If this issue has come up before and the proposed change is not the direction `MDsveX` wants to take, I apologize and will respect decisions made by code owner.

Thank you!