### PR TITLE
Pass filename to highlighter

### DIFF
--- a/.changeset/ten-trainers-reply.md
+++ b/.changeset/ten-trainers-reply.md
@@ -1,0 +1,5 @@
+---
+"mdsvex": patch
+---
+
+Pass filename to highlighter

--- a/.changeset/wild-sloths-drop.md
+++ b/.changeset/wild-sloths-drop.md
@@ -1,0 +1,5 @@
+---
+'mdsvex': minor
+---
+
+Pass filename to highligher

--- a/.changeset/wild-sloths-drop.md
+++ b/.changeset/wild-sloths-drop.md
@@ -1,5 +1,0 @@
----
-'mdsvex': minor
----
-
-Pass filename to highligher

--- a/packages/mdsvex/src/transformers/index.ts
+++ b/packages/mdsvex/src/transformers/index.ts
@@ -547,7 +547,7 @@ export function highlight_blocks({
 		}
 	}
 
-	return async function (tree) {
+	return async function (tree, vFile) {
 		if (highlight_fn) {
 			const nodes: (Code | HTML)[] = [];
 			visit<Code>(tree, 'code', (node) => {
@@ -560,7 +560,9 @@ export function highlight_blocks({
 					node.value = await highlight_fn(
 						node.value,
 						(node as Code).lang,
-						(node as Code).meta
+						(node as Code).meta,
+						//@ts-ignore
+						vFile.filename
 					);
 				})
 			);

--- a/packages/mdsvex/src/types.ts
+++ b/packages/mdsvex/src/types.ts
@@ -153,7 +153,8 @@ export type Layout = Record<string, LayoutMeta>;
 export type Highlighter = (
 	code: string,
 	lang: string | null | undefined,
-	metastring: string | null | undefined
+	metastring: string | null | undefined,
+	filename?: string
 ) => string | Promise<string>;
 interface HighlightOptions {
 	/**


### PR DESCRIPTION
## Context

Today, as of [mdsvex@0.11.0](https://github.com/pngwn/MDsveX/releases/tag/mdsvex%400.11.0), a custom [highlighter function](https://mdsvex.pngwn.io/docs#highlight) is not aware of the filename of the file being processed by MDsveX, and there is no way (that i am aware of) to get around this using the public API.

This issue adds such support by passing additional `filename` positional param for highlighter.

## Rationale

Having `filename` in highlighter will allow more complex customization. Specifically, I'm trying to have the syntax highlighter read the source code from file system provided in a meta line, something like this:

    ```svelte
    /// source=./examples/an-example.svelte
    ```

This allows keeping certain example source code in a separate file, making better use of editor support, enabling reusability of said source code, and keeping the MDsveX file succinct.