### PR TITLE
Infer the settings type when using unified plugins with settings

### DIFF
--- a/.changeset/dry-houses-pay.md
+++ b/.changeset/dry-houses-pay.md
@@ -1,0 +1,5 @@
+---
+"mdsvex": patch
+---
+
+Infer the settings type when using unified plugins with settings

--- a/packages/mdsvex/src/types.ts
+++ b/packages/mdsvex/src/types.ts
@@ -182,7 +182,10 @@ interface HighlightOptions {
 	alias?: Record<string, string>;
 }
 
-export type PluginWithSettings<S extends any[] = [Settings?], P extends Plugin<S> = Plugin<S>> = [P, ...S]
+export type PluginWithSettings<
+	S extends any[] = [Settings?],
+	P extends Plugin<S> = Plugin<S>
+> = [P, ...S];
 export type UnifiedPlugins = Array<PluginWithSettings | Plugin>;
 
 export interface TransformOptions {
@@ -304,10 +307,10 @@ export interface MdsvexCompileOptions extends MdsvexOptions {
 
 export type PreprocessorReturn = Promise<
 	| {
-		code: string;
-		data?: Record<string, unknown>;
-		map?: string;
-	}
+			code: string;
+			data?: Record<string, unknown>;
+			map?: string;
+	  }
 	| undefined
 >;
 

--- a/packages/mdsvex/src/types.ts
+++ b/packages/mdsvex/src/types.ts
@@ -182,7 +182,8 @@ interface HighlightOptions {
 	alias?: Record<string, string>;
 }
 
-export type UnifiedPlugins = Array<[Plugin, Settings] | Plugin>;
+export type PluginWithSettings<S extends any[] = [Settings?], P extends Plugin<S> = Plugin<S>> = [P, ...S]
+export type UnifiedPlugins = Array<PluginWithSettings | Plugin>;
 
 export interface TransformOptions {
 	remarkPlugins?: UnifiedPlugins;
@@ -303,10 +304,10 @@ export interface MdsvexCompileOptions extends MdsvexOptions {
 
 export type PreprocessorReturn = Promise<
 	| {
-			code: string;
-			data?: Record<string, unknown>;
-			map?: string;
-	  }
+		code: string;
+		data?: Record<string, unknown>;
+		map?: string;
+	}
 	| undefined
 >;
 


### PR DESCRIPTION
This enables TypeScript to autocomplete the types of settings passed to unified plugins like so:
```js
mdsvex({
	rehypePlugins: [[rehypeExternalLinks, { target: "_blank" }]]
})
```