### PR TITLE
allow svelte 5 in peerDependencies

### DIFF
--- a/packages/mdsvex/package.json
+++ b/packages/mdsvex/package.json
@@ -59,7 +59,7 @@
 		"vfile": "^4.2.0"
 	},
 	"peerDependencies": {
-		"svelte": ">=3 <5"
+		"svelte": ">=3 <6"
 	},
 	"dependencies": {
 		"@types/unist": "^2.0.3",


### PR DESCRIPTION
Adds Svelte 5. Currently, this may only be installed alongside Svelte 5 with `--legacy-peer-deps` or `--force`

See https://github.com/pngwn/MDsveX/issues/555 

Users on that issue report being able to use the library with Svelte 5, except for the peer dependency issue. I also recently implemented a blog with `"mdsvex": "^0.11.0"` and `"svelte": "^5.0.0-next.1"`.

It looks like testing happens with Svelte 4. If desired I could try to matrix the version.