### PR TITLE
Frontmatter containing `$1` is correctly substituted

### DIFF
--- a/packages/mdsvex/src/transformers/index.ts
+++ b/packages/mdsvex/src/transformers/index.ts
@@ -380,7 +380,7 @@ export function transform_hast({
 				// @ts-ignore
 				_module[0].value = _module[0].value.replace(
 					RE_MODULE_SCRIPT,
-					`$1${newline}\t${fm}`
+					(match: string) => `${match}${newline}\t${fm}`
 				);
 			}
 

--- a/packages/mdsvex/test/_fixtures/hybrid/input/dollar-one-in-frontmatter.svx
+++ b/packages/mdsvex/test/_fixtures/hybrid/input/dollar-one-in-frontmatter.svx
@@ -1,0 +1,5 @@
+---
+price: '$10'
+---
+<script context="module">
+</script>

--- a/packages/mdsvex/test/_fixtures/hybrid/output/dollar-one-in-frontmatter.svelte
+++ b/packages/mdsvex/test/_fixtures/hybrid/output/dollar-one-in-frontmatter.svelte
@@ -1,0 +1,4 @@
+<script context="module">
+export const metadata = {"price":"$10"};
+const { price } = metadata;
+</script>


### PR DESCRIPTION
Without this change, the script itself could be inserted into the metadata string.

Before,
```
---
price: '$10'
---
<script context="module">
</script>
```

becomes

```svelte
<script·context="module">
export const metadata = {"price":"<script·context="module">0"};
const {·price·} = metadata;
</script>
```

The correct behavior is to keep the string as-is:
```svelte
<script context="module">
export const metadata = {"price":"$10"};
const { price } = metadata;
</script>
```