### PR TITLE
add exports map to package.json

### DIFF
--- a/.changeset/long-comics-march.md
+++ b/.changeset/long-comics-march.md
@@ -1,0 +1,5 @@
+---
+"mdsvex": minor
+---
+
+add exports map to package.json and cleanup build output. 

--- a/packages/mdsvex/package.json
+++ b/packages/mdsvex/package.json
@@ -2,9 +2,14 @@
 	"name": "mdsvex",
 	"version": "0.11.2",
 	"description": "Markdown preprocessor for Svelte",
-	"main": "dist/main.cjs.js",
-	"module": "dist/main.es.js",
-	"browser": "dist/mdsvex.js",
+	"exports": {
+		".": {
+			"require": "dist/main.cjs",
+			"default": "dist/main.mjs"
+		}
+	},
+	"main": "dist/main.cjs",
+	"module": "dist/main.mjs",
 	"repository": "https://github.com/pngwn/MDsveX",
 	"scripts": {
 		"build": "rollup -c"

--- a/packages/mdsvex/rollup.config.js
+++ b/packages/mdsvex/rollup.config.js
@@ -33,28 +33,4 @@ export default [
 			{ file: 'dist/main.cjs.d.ts', format: 'cjs' },
 		],
 	},
-	{
-		plugins: [
-			replace({
-				'(process ).browser': true,
-				'(process as RollupProcess).browser': true,
-				delimiters: ['', ''],
-			}),
-			resolve({ browser: true }),
-			commonjs({ namedExports: { 'svelte/compiler': ['parse'] } }),
-			json(),
-			sucrase({ transforms: ['typescript'] }),
-			globals(),
-			builtins(),
-		],
-		input: 'src/main.ts',
-		output: [
-			{
-				file: 'dist/browser-umd.js',
-				name: 'mdsvex',
-				format: 'umd',
-				sourcemap: false,
-			},
-		],
-	},
 ];

--- a/packages/mdsvex/rollup.config.js
+++ b/packages/mdsvex/rollup.config.js
@@ -57,28 +57,4 @@ export default [
 			},
 		],
 	},
-	{
-		plugins: [
-			replace({
-				'(process ).browser': true,
-				'(process as RollupProcess).browser': true,
-				delimiters: ['', ''],
-			}),
-			resolve({ browser: true }),
-			commonjs({ namedExports: { 'svelte/compiler': ['parse'] } }),
-			json(),
-			sucrase({ transforms: ['typescript'] }),
-			globals(),
-			builtins(),
-		],
-		input: 'src/main.ts',
-		output: [
-			{
-				file: 'dist/browser-es.js',
-				name: 'mdsvex',
-				format: 'es',
-				sourcemap: false,
-			},
-		],
-	},
 ];


### PR DESCRIPTION
fixes a couple of issues:
- extension for module must be `.mjs` for node compatibility
- removed `browser` field because that file didn't resolve, so no one could have been using it