### PR TITLE
run tests with pnpm -r

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 	"scripts": {
 		"lint": "prettier --check .",
 		"format": "prettier --write .",
-		"test": "uvu -r ts-node/register packages test.ts$",
+		"test": "pnpm -r --filter=!site test",
 		"test:filter": "uvu -r ts-node/register",
 		"release": "pnpm -r build && changeset publish",
 		"changeset:add": "changeset add",

--- a/packages/mdsvex/package.json
+++ b/packages/mdsvex/package.json
@@ -12,7 +12,8 @@
 	"module": "dist/main.mjs",
 	"repository": "https://github.com/pngwn/MDsveX",
 	"scripts": {
-		"build": "rollup -c"
+		"build": "rollup -c",
+		"test": "uvu -r ts-node/register test test.ts$"
 	},
 	"files": [
 		"dist/*",

--- a/packages/svast/package.json
+++ b/packages/svast/package.json
@@ -3,9 +3,6 @@
 	"version": "0.2.0",
 	"description": "Types for svast, a Svelte AST specification",
 	"main": "index.js",
-	"scripts": {
-		"test": "echo \"Error: no test specified\" && exit 1"
-	},
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/pngwn/MDsveX/tree/master/packages/svast"


### PR DESCRIPTION
It's nice to be able to run the `mdsvex` tests on a standalone basis. It'd also allow you to incrementally migrate one project at a time to vitest