### PR TITLE
fix: prevent race condition with `add_layouts`

### DIFF
--- a/.changeset/nice-pumas-hug.md
+++ b/.changeset/nice-pumas-hug.md
@@ -1,0 +1,5 @@
+---
+"mdsvex": patch
+---
+
+fix: prevent race condition with `add_layouts`

--- a/packages/mdsvex/src/index.ts
+++ b/packages/mdsvex/src/index.ts
@@ -309,8 +309,10 @@ export const mdsvex = (options: MdsvexOptions = defaults): Preprocessor => {
 			let _layout: Layout = {};
 			let layout_mode: LayoutMode = 'single';
 
+			// if `layout_processed` is undefined, we need to process the layouts
 			if (!layouts_processed && !is_browser) {
 				let resolve: () => void | undefined;
+				// set `layout_processed` before the first await to prevent race conditions
 				layouts_processed = new Promise((r) => (resolve = r));
 				await handle_path();
 				if (typeof layout === 'string') {
@@ -329,6 +331,8 @@ export const mdsvex = (options: MdsvexOptions = defaults): Preprocessor => {
 				}
 				_layout = await process_layouts(_layout);
 				parser.add_layouts(_layout, layout_mode);
+				// resolve the `layout_processed` promise to unlock the rest of the file
+				// that are waiting before calling parser.process
 				resolve!();
 			}
 
@@ -341,6 +345,8 @@ export const mdsvex = (options: MdsvexOptions = defaults): Preprocessor => {
 			);
 			if (!extensionsParts.some((ext) => filename.endsWith(ext))) return;
 
+			// before calling parser.process, we need to wait for the layouts to be processed
+			// or else the parser will be frozen
 			await layouts_processed;
 			const parsed = await parser.process({ contents: content, filename });
 			return {

--- a/packages/mdsvex/test/it/mdsvex.spec.ts
+++ b/packages/mdsvex/test/it/mdsvex.spec.ts
@@ -1171,13 +1171,6 @@ I am some paragraph text
 test('it should not incur in race conditions if multiple invocations happens at the same time', async () => {
 	const preprocessor = mdsvex();
 
-	// slowdown importing path to cause the race condition
-	vi.doMock(import('path'), async (importOriginal) => {
-		const mod = await importOriginal(); // type is inferred
-		await new Promise((r) => setTimeout(r, 100));
-		return mod;
-	});
-
 	const output_promise = preprocessor.markup({
 		content: `# hello`,
 		filename: 'file.svx',
@@ -1193,7 +1186,4 @@ test('it should not incur in race conditions if multiple invocations happens at 
 
 	expect(lines(output?.code)).toEqual(lines(`<h1>hello</h1>`));
 	expect(lines(second_output?.code)).toEqual(lines(`<h1>hello</h1>`));
-
-	vi.resetModules();
-	vi.unmock('path');
 });


### PR DESCRIPTION
Upgrading to the latest `mdsvex` made the build of my project fail...while investigating the reason i found the culprit here...basically since the preprocessor is invoked on multiple files it could happen that on some files they enter the `if` that guards the `add_layouts` even after some file already called `parser.process` which means that the `parser` is already frozen.

This also meant that the code to process the layouts were unnecessarily run multiple times.

I've tried to create a reproduction to add a test but i failed to do so...on my pc if i build my project `handle_path` takes up to 30ms to complete (which causes the race condition)...but on a fresh project `handle_path` doesn't take more than 0.2 ms. Which is weird because `handle_path` just imports `path` from node. 🤷🏼 

However this should fix it.

Closes #718. 