### PR TITLE
docs: Avoid explicit shiki languages list

### DIFF
--- a/packages/site/src/routes/_docs.svtext
+++ b/packages/site/src/routes/_docs.svtext
@@ -689,20 +689,19 @@ Frontmatter also interacts with layouts, you can find more details in the [Layou
 You can use shiki for highlighting rather than prism by leveraging the `highlighter` option:
 
 ```js
-import { mdsvex } from 'mdsvex';
-import { createHighlighter } from 'shiki';
+import { escapeSvelte } from 'mdsvex';
+import { codeToHtml } from 'shiki';
 
 const theme = 'github-dark';
-const highlighter = await createHighlighter({
-	themes: [theme],
-	langs: ['javascript', 'typescript']
-});
 
 /** @type {import('mdsvex').MdsvexOptions} */
 const mdsvexOptions = {
 	highlight: {
-		highlighter: (code, lang = 'text') => highlighter.codeToHtml(code, { lang, theme })
-	},
+		async highlighter(code, lang = 'text') {
+			const html = await codeToHtml(code, { lang, theme });
+			return `{@html \`${escapeSvelte(html)}\` }`;
+		}
+	}
 }
 ```
 


### PR DESCRIPTION
The approach to shiki usage in the current documentation requires explicit listing of all of the needed languages. This makes shiki+mdsvex use challenging.

Given [`highlighter`](https://github.com/pngwn/MDsveX/blob/main/packages/mdsvex/src/types.ts#L173) expects and `shiki.codeToHtml` returns `Promise<string>`, we can avoid having to precompile with an explicit list.

Relates to #636