### PR TITLE
Migrate from `context="module"` to `module`

### DIFF
--- a/.changeset/svelte5-module-syntax.md
+++ b/.changeset/svelte5-module-syntax.md
@@ -1,0 +1,5 @@
+---
+"mdsvex": minor
+---
+
+feat: add `svelte5` option to enable `<script module>` syntax

--- a/packages/mdsvex/src/index.ts
+++ b/packages/mdsvex/src/index.ts
@@ -71,7 +71,11 @@ export function transform(
 		highlight,
 	} = {} as Omit<TransformOptions, 'layout_mode' | 'layout'>
 ): Processor & {
-	add_layouts: (layout: Layout, layout_mode: LayoutMode) => void;
+	add_layouts: (
+		layout: Layout,
+		layout_mode: LayoutMode,
+		svelte5?: boolean
+	) => void;
 } {
 	const fm_opts = frontmatter
 		? frontmatter
@@ -106,11 +110,19 @@ export function transform(
 		allowDangerousHtml: true,
 		allowDangerousCharacters: true,
 	}) as Processor & {
-		add_layouts: (layout: Layout, layout_mode: LayoutMode) => void;
+		add_layouts: (
+			layout: Layout,
+			layout_mode: LayoutMode,
+			svelte5?: boolean
+		) => void;
 	};
 
-	processor.add_layouts = (layout: Layout, layout_mode: LayoutMode) => {
-		processor.use(transform_hast, { layout: layout, layout_mode });
+	processor.add_layouts = (
+		layout: Layout,
+		layout_mode: LayoutMode,
+		svelte5: boolean = false
+	) => {
+		processor.use(transform_hast, { layout: layout, layout_mode, svelte5 });
 	};
 
 	return processor;
@@ -249,6 +261,7 @@ export const mdsvex = (options: MdsvexOptions = defaults): Preprocessor => {
 		layout = false,
 		highlight = { highlighter: code_highlight, optimise: true },
 		frontmatter,
+		svelte5 = false,
 	} = options;
 
 	if (highlight === undefined) {
@@ -279,6 +292,7 @@ export const mdsvex = (options: MdsvexOptions = defaults): Preprocessor => {
 		'layout',
 		'highlight',
 		'frontmatter',
+		'svelte5',
 	];
 
 	for (const opt in options) {
@@ -330,7 +344,7 @@ export const mdsvex = (options: MdsvexOptions = defaults): Preprocessor => {
 					}
 				}
 				_layout = await process_layouts(_layout);
-				parser.add_layouts(_layout, layout_mode);
+				parser.add_layouts(_layout, layout_mode, svelte5);
 				// resolve the `layout_processed` promise to unlock the rest of the file
 				// that are waiting before calling parser.process
 				resolve!();

--- a/packages/mdsvex/src/transformers/index.ts
+++ b/packages/mdsvex/src/transformers/index.ts
@@ -130,7 +130,7 @@ export function smartypants_transformer(options = {}): Transformer {
 // regex for scripts and attributes
 
 const attrs = `(?:\\s{0,1}[a-zA-z]+=(?:"){0,1}[a-zA-Z0-9]+(?:"){0,1})*`;
-const context = `(?:\\s{0,1}context)=(?:"){0,1}module(?:"){0,1}`;
+const context = `(?:\\s{0,1}(?:context=(?:"){0,1}module(?:"){0,1}|module))`;
 
 const RE_BLANK = /^\n+$|^\s+$/;
 
@@ -309,9 +309,11 @@ export const handle_path = async (): Promise<void> => {
 export function transform_hast({
 	layout,
 	layout_mode,
+	svelte5 = false,
 }: {
 	layout: Layout | undefined;
 	layout_mode: LayoutMode;
+	svelte5?: boolean;
 }): Transformer {
 	return function transformer(tree, vFile) {
 		// we need to keep { and } intact for svelte, so reverse the escaping in links and images
@@ -405,10 +407,13 @@ export function transform_hast({
 			}
 
 			// inject the frontmatter into the module script if there is any, reusing the existing module script if one exists
+			const module_script_tag = svelte5
+				? '<script module>'
+				: '<script context="module">';
 			if (!_module[0] && fm) {
 				_module.push({
 					type: 'raw',
-					value: `<script context="module">${newline}\t${fm}${newline}</script>`,
+					value: `${module_script_tag}${newline}\t${fm}${newline}</script>`,
 				});
 			} else if (fm) {
 				// @ts-ignore

--- a/packages/mdsvex/src/types.ts
+++ b/packages/mdsvex/src/types.ts
@@ -296,6 +296,17 @@ export interface MdsvexOptions {
 	 * ```
 	 */
 	layout?: string | Record<string, string>;
+	/**
+	 * **svelte5** - Use Svelte 5 syntax for module scripts (`<script module>` instead of `<script context="module">`). Default: `false`.
+	 *
+	 * Set this to `true` if you are using Svelte 5.
+	 *
+	 *  *example:*
+	 * ```js
+	 * svelte5: true
+	 * ```
+	 */
+	svelte5?: boolean;
 }
 
 /**

--- a/packages/mdsvex/test/it/mdsvex.spec.ts
+++ b/packages/mdsvex/test/it/mdsvex.spec.ts
@@ -488,6 +488,71 @@ number: 999
 	);
 });
 
+test('YAML front-matter should use Svelte 5 syntax when svelte5 option is true', async () => {
+	const output = await mdsvex({ svelte5: true }).markup({
+		content: `---
+string: value
+string2: 'value2'
+array: [1, 2, 3]
+number: 999
+---
+
+# hello
+`,
+		filename: 'file.svx',
+	});
+
+	expect(lines(output?.code)).toEqual(
+		lines(`<script module>
+	export const metadata = {"string":"value","string2":"value2","array":[1,2,3],"number":999};
+	const { string, string2, array, number } = metadata;
+</script>
+
+<h1>hello</h1>
+`)
+	);
+});
+
+test('YAML front-matter should use Svelte 5 syntax with layouts when svelte5 option is true', async () => {
+	const output = await mdsvex({
+		svelte5: true,
+		layout: join(fix_dir, 'Layout.svelte'),
+	}).markup({
+		content: `---
+string: value
+string2: 'value2'
+array: [1, 2, 3]
+number: 999
+---
+
+<script>
+	let thing = 27;
+</script>
+
+# hello
+`,
+		filename: 'file.svx',
+	});
+
+	expect(lines(output?.code)).toEqual(
+		lines(`<script module>
+	export const metadata = {"string":"value","string2":"value2","array":[1,2,3],"number":999};
+	const { string, string2, array, number } = metadata;
+</script>
+
+<script>
+	import Layout_MDSVEX_DEFAULT from '${to_posix(join(fix_dir, 'Layout.svelte'))}';
+	let thing = 27;
+</script>
+
+<Layout_MDSVEX_DEFAULT {...$$props} {...metadata}>
+
+<h1>hello</h1>
+
+</Layout_MDSVEX_DEFAULT>`)
+	);
+});
+
 test('YAML front-matter should be injected into the component module script - even if there is already a module script', async () => {
 	const output = await mdsvex().markup({
 		content: `---
@@ -788,7 +853,7 @@ number: 999
 	await output_fn();
 
 	expect(warning).toEqual(
-		'mdsvex: Received unknown options: bip, bop, boom. Valid options are: filename, remarkPlugins, rehypePlugins, smartypants, extension, extensions, layout, highlight, frontmatter.'
+		'mdsvex: Received unknown options: bip, bop, boom. Valid options are: filename, remarkPlugins, rehypePlugins, smartypants, extension, extensions, layout, highlight, frontmatter, svelte5.'
 	);
 
 	console.warn = console_warn;

--- a/packages/site/src/routes/_docs.svtext
+++ b/packages/site/src/routes/_docs.svtext
@@ -663,7 +663,7 @@ author: Dr. Fabuloso the Fabulous
 Some amazing content.
 ```
 
-Additionally, all of these variables are exported as a single object named `metadata` from the `context="module"` (or `<script module>` in  Svelte 5+) script, so they can easily be imported in javascript:
+Additionally, all of these variables are exported as a single object named `metadata` from the `context="module"` (or `<script module>` in Svelte 5+) script, so they can easily be imported in javascript:
 
 ```svelte
 <script context="module">

--- a/packages/site/src/routes/_docs.svtext
+++ b/packages/site/src/routes/_docs.svtext
@@ -605,7 +605,7 @@ Would normally compile to:
 </ul>
 ```
 
-Custom components allow you to replace these elements with components. You can define components by exporting named exports from the `context="module"` script of your Layout file:
+Custom components allow you to replace these elements with components. You can define components by exporting named exports from the `context="module"` script (or `<script module>` in Svelte 5+) of your Layout file:
 
 ```svelte
 <script context="module">
@@ -663,7 +663,7 @@ author: Dr. Fabuloso the Fabulous
 Some amazing content.
 ```
 
-Additionally, all of these variables are exported as a single object named `metadata` from the `context="module"` script, so they can easily be imported in javascript:
+Additionally, all of these variables are exported as a single object named `metadata` from the `context="module"` (or `<script module>` in  Svelte 5+) script, so they can easily be imported in javascript:
 
 ```svelte
 <script context="module">

--- a/packages/svelte-parse/test/fixtures/script-module-basic/input.svelte
+++ b/packages/svelte-parse/test/fixtures/script-module-basic/input.svelte
@@ -1,0 +1,9 @@
+<script module>
+	export const prerender = true;
+</script>
+
+<script>
+	export let name = 'world';
+</script>
+
+<h1>Hello {name}!</h1>

--- a/packages/svelte-parse/test/fixtures/script-module-basic/output.json
+++ b/packages/svelte-parse/test/fixtures/script-module-basic/output.json
@@ -1,0 +1,224 @@
+{
+	"type": "root",
+	"children": [
+		{
+			"type": "svelteScript",
+			"tagName": "script",
+			"properties": [
+				{
+					"type": "svelteProperty",
+					"name": "module",
+					"value": [],
+					"modifiers": [],
+					"shorthand": "boolean",
+					"position": {
+						"start": {
+							"line": 1,
+							"column": 9,
+							"offset": 8
+						},
+						"end": {
+							"line": 1,
+							"column": 15,
+							"offset": 14
+						}
+					}
+				}
+			],
+			"selfClosing": false,
+			"children": [
+				{
+					"type": "text",
+					"value": "\n\texport const prerender = true;\n",
+					"position": {
+						"start": {
+							"line": 1,
+							"column": 16,
+							"offset": 15
+						},
+						"end": {
+							"line": 3,
+							"column": 1,
+							"offset": 48
+						}
+					}
+				}
+			],
+			"position": {
+				"start": {
+					"line": 1,
+					"column": 1,
+					"offset": 0
+				},
+				"end": {
+					"line": 3,
+					"column": 10,
+					"offset": 57
+				}
+			}
+		},
+		{
+			"type": "text",
+			"value": "\n\n",
+			"position": {
+				"start": {
+					"line": 3,
+					"column": 10,
+					"offset": 57
+				},
+				"end": {
+					"line": 5,
+					"column": 1,
+					"offset": 59
+				}
+			}
+		},
+		{
+			"type": "svelteScript",
+			"tagName": "script",
+			"properties": [],
+			"selfClosing": false,
+			"children": [
+				{
+					"type": "text",
+					"value": "\n\texport let name = 'world';\n",
+					"position": {
+						"start": {
+							"line": 5,
+							"column": 9,
+							"offset": 67
+						},
+						"end": {
+							"line": 7,
+							"column": 1,
+							"offset": 96
+						}
+					}
+				}
+			],
+			"position": {
+				"start": {
+					"line": 5,
+					"column": 1,
+					"offset": 59
+				},
+				"end": {
+					"line": 7,
+					"column": 10,
+					"offset": 105
+				}
+			}
+		},
+		{
+			"type": "text",
+			"value": "\n\n",
+			"position": {
+				"start": {
+					"line": 7,
+					"column": 10,
+					"offset": 105
+				},
+				"end": {
+					"line": 9,
+					"column": 1,
+					"offset": 107
+				}
+			}
+		},
+		{
+			"type": "svelteElement",
+			"tagName": "h1",
+			"properties": [],
+			"selfClosing": false,
+			"children": [
+				{
+					"type": "text",
+					"value": "Hello ",
+					"position": {
+						"start": {
+							"line": 9,
+							"column": 5,
+							"offset": 111
+						},
+						"end": {
+							"line": 9,
+							"column": 11,
+							"offset": 117
+						}
+					}
+				},
+				{
+					"type": "svelteDynamicContent",
+					"position": {
+						"start": {
+							"line": 9,
+							"column": 11,
+							"offset": 117
+						},
+						"end": {
+							"line": 9,
+							"column": 17,
+							"offset": 123
+						}
+					},
+					"expression": {
+						"type": "svelteExpression",
+						"value": "name",
+						"position": {
+							"start": {
+								"line": 9,
+								"column": 12,
+								"offset": 118
+							},
+							"end": {
+								"line": 9,
+								"column": 16,
+								"offset": 122
+							}
+						}
+					}
+				},
+				{
+					"type": "text",
+					"value": "!",
+					"position": {
+						"start": {
+							"line": 9,
+							"column": 17,
+							"offset": 123
+						},
+						"end": {
+							"line": 9,
+							"column": 18,
+							"offset": 124
+						}
+					}
+				}
+			],
+			"position": {
+				"start": {
+					"line": 9,
+					"column": 1,
+					"offset": 107
+				},
+				"end": {
+					"line": 9,
+					"column": 23,
+					"offset": 129
+				}
+			}
+		}
+	],
+	"position": {
+		"start": {
+			"column": 1,
+			"line": 1,
+			"offset": 0
+		},
+		"end": {
+			"line": 9,
+			"column": 23,
+			"offset": 129
+		}
+	}
+}

--- a/packages/svelte-parse/test/fixtures/script-module-only/input.svelte
+++ b/packages/svelte-parse/test/fixtures/script-module-only/input.svelte
@@ -1,0 +1,6 @@
+<script module>
+	export const ssr = false;
+	export const prerender = true;
+</script>
+
+<p>Static content only</p>

--- a/packages/svelte-parse/test/fixtures/script-module-only/output.json
+++ b/packages/svelte-parse/test/fixtures/script-module-only/output.json
@@ -1,0 +1,125 @@
+{
+	"type": "root",
+	"children": [
+		{
+			"type": "svelteScript",
+			"tagName": "script",
+			"properties": [
+				{
+					"type": "svelteProperty",
+					"name": "module",
+					"value": [],
+					"modifiers": [],
+					"shorthand": "boolean",
+					"position": {
+						"start": {
+							"line": 1,
+							"column": 9,
+							"offset": 8
+						},
+						"end": {
+							"line": 1,
+							"column": 15,
+							"offset": 14
+						}
+					}
+				}
+			],
+			"selfClosing": false,
+			"children": [
+				{
+					"type": "text",
+					"value": "\n\texport const ssr = false;\n\texport const prerender = true;\n",
+					"position": {
+						"start": {
+							"line": 1,
+							"column": 16,
+							"offset": 15
+						},
+						"end": {
+							"line": 4,
+							"column": 1,
+							"offset": 75
+						}
+					}
+				}
+			],
+			"position": {
+				"start": {
+					"line": 1,
+					"column": 1,
+					"offset": 0
+				},
+				"end": {
+					"line": 4,
+					"column": 10,
+					"offset": 84
+				}
+			}
+		},
+		{
+			"type": "text",
+			"value": "\n\n",
+			"position": {
+				"start": {
+					"line": 4,
+					"column": 10,
+					"offset": 84
+				},
+				"end": {
+					"line": 6,
+					"column": 1,
+					"offset": 86
+				}
+			}
+		},
+		{
+			"type": "svelteElement",
+			"tagName": "p",
+			"properties": [],
+			"selfClosing": false,
+			"children": [
+				{
+					"type": "text",
+					"value": "Static content only",
+					"position": {
+						"start": {
+							"line": 6,
+							"column": 4,
+							"offset": 89
+						},
+						"end": {
+							"line": 6,
+							"column": 23,
+							"offset": 108
+						}
+					}
+				}
+			],
+			"position": {
+				"start": {
+					"line": 6,
+					"column": 1,
+					"offset": 86
+				},
+				"end": {
+					"line": 6,
+					"column": 27,
+					"offset": 112
+				}
+			}
+		}
+	],
+	"position": {
+		"start": {
+			"column": 1,
+			"line": 1,
+			"offset": 0
+		},
+		"end": {
+			"line": 6,
+			"column": 27,
+			"offset": 112
+		}
+	}
+}

--- a/packages/svelte-parse/test/fixtures/script-module-with-lang/input.svelte
+++ b/packages/svelte-parse/test/fixtures/script-module-with-lang/input.svelte
@@ -1,0 +1,12 @@
+<script module lang="ts">
+	export const prerender = true;
+	export type PageData = {
+		title: string;
+	};
+</script>
+
+<script lang="ts">
+	export let data: PageData;
+</script>
+
+<h1>{data.title}</h1>

--- a/packages/svelte-parse/test/fixtures/script-module-with-lang/output.json
+++ b/packages/svelte-parse/test/fixtures/script-module-with-lang/output.json
@@ -1,0 +1,265 @@
+{
+	"type": "root",
+	"children": [
+		{
+			"type": "svelteScript",
+			"tagName": "script",
+			"properties": [
+				{
+					"type": "svelteProperty",
+					"name": "module",
+					"value": [],
+					"modifiers": [],
+					"shorthand": "boolean",
+					"position": {
+						"start": {
+							"line": 1,
+							"column": 9,
+							"offset": 8
+						},
+						"end": {
+							"line": 1,
+							"column": 15,
+							"offset": 14
+						}
+					}
+				},
+				{
+					"type": "svelteProperty",
+					"name": "lang",
+					"value": [
+						{
+							"type": "text",
+							"value": "ts",
+							"position": {
+								"start": {
+									"line": 1,
+									"column": 22,
+									"offset": 21
+								},
+								"end": {
+									"line": 1,
+									"column": 25,
+									"offset": 24
+								}
+							}
+						}
+					],
+					"modifiers": [],
+					"shorthand": "none",
+					"position": {
+						"start": {
+							"line": 1,
+							"column": 16,
+							"offset": 15
+						},
+						"end": {
+							"line": 1,
+							"column": 25,
+							"offset": 24
+						}
+					}
+				}
+			],
+			"selfClosing": false,
+			"children": [
+				{
+					"type": "text",
+					"value": "\n\texport const prerender = true;\n\texport type PageData = {\n\t\ttitle: string;\n\t};\n",
+					"position": {
+						"start": {
+							"line": 1,
+							"column": 26,
+							"offset": 25
+						},
+						"end": {
+							"line": 6,
+							"column": 1,
+							"offset": 105
+						}
+					}
+				}
+			],
+			"position": {
+				"start": {
+					"line": 1,
+					"column": 1,
+					"offset": 0
+				},
+				"end": {
+					"line": 6,
+					"column": 10,
+					"offset": 114
+				}
+			}
+		},
+		{
+			"type": "text",
+			"value": "\n\n",
+			"position": {
+				"start": {
+					"line": 6,
+					"column": 10,
+					"offset": 114
+				},
+				"end": {
+					"line": 8,
+					"column": 1,
+					"offset": 116
+				}
+			}
+		},
+		{
+			"type": "svelteScript",
+			"tagName": "script",
+			"properties": [
+				{
+					"type": "svelteProperty",
+					"name": "lang",
+					"value": [
+						{
+							"type": "text",
+							"value": "ts",
+							"position": {
+								"start": {
+									"line": 8,
+									"column": 15,
+									"offset": 130
+								},
+								"end": {
+									"line": 8,
+									"column": 18,
+									"offset": 133
+								}
+							}
+						}
+					],
+					"modifiers": [],
+					"shorthand": "none",
+					"position": {
+						"start": {
+							"line": 8,
+							"column": 9,
+							"offset": 124
+						},
+						"end": {
+							"line": 8,
+							"column": 18,
+							"offset": 133
+						}
+					}
+				}
+			],
+			"selfClosing": false,
+			"children": [
+				{
+					"type": "text",
+					"value": "\n\texport let data: PageData;\n",
+					"position": {
+						"start": {
+							"line": 8,
+							"column": 19,
+							"offset": 134
+						},
+						"end": {
+							"line": 10,
+							"column": 1,
+							"offset": 163
+						}
+					}
+				}
+			],
+			"position": {
+				"start": {
+					"line": 8,
+					"column": 1,
+					"offset": 116
+				},
+				"end": {
+					"line": 10,
+					"column": 10,
+					"offset": 172
+				}
+			}
+		},
+		{
+			"type": "text",
+			"value": "\n\n",
+			"position": {
+				"start": {
+					"line": 10,
+					"column": 10,
+					"offset": 172
+				},
+				"end": {
+					"line": 12,
+					"column": 1,
+					"offset": 174
+				}
+			}
+		},
+		{
+			"type": "svelteElement",
+			"tagName": "h1",
+			"properties": [],
+			"selfClosing": false,
+			"children": [
+				{
+					"type": "svelteDynamicContent",
+					"position": {
+						"start": {
+							"line": 12,
+							"column": 5,
+							"offset": 178
+						},
+						"end": {
+							"line": 12,
+							"column": 17,
+							"offset": 190
+						}
+					},
+					"expression": {
+						"type": "svelteExpression",
+						"value": "data.title",
+						"position": {
+							"start": {
+								"line": 12,
+								"column": 6,
+								"offset": 179
+							},
+							"end": {
+								"line": 12,
+								"column": 16,
+								"offset": 189
+							}
+						}
+					}
+				}
+			],
+			"position": {
+				"start": {
+					"line": 12,
+					"column": 1,
+					"offset": 174
+				},
+				"end": {
+					"line": 12,
+					"column": 22,
+					"offset": 195
+				}
+			}
+		}
+	],
+	"position": {
+		"start": {
+			"column": 1,
+			"line": 1,
+			"offset": 0
+		},
+		"end": {
+			"line": 12,
+			"column": 22,
+			"offset": 195
+		}
+	}
+}


### PR DESCRIPTION
This fixes the deprecation warning given by the Svelte v5 compiler: https://svelte.dev/docs/svelte/compiler-warnings#script_context_deprecated

This PR introduces an opt-in configuration item to enable Svelte v5 syntax, which breaks nothing but lets people on the newer version use the new syntax as well. Essentially:

- it's explicit and requires opt-in
- it's backwards-compatible, defaults to old context syntax
- doesn't require runtime detection
- easy path forward when deprecating: swap default to true, and then false enables Svelte v3/v4 support

I couldn't generate a changeset, for whatever reason: `🦋  error Error: Failed to find where HEAD diverged from master. Does master exist?`

Closes #649