### PR TITLE
fix: support Svelte 5 runes with mdsvex layouts

### DIFF
--- a/.changeset/svelte-runes-layout-props.md
+++ b/.changeset/svelte-runes-layout-props.md
@@ -1,0 +1,5 @@
+---
+'mdsvex': patch
+---
+
+Add a `layoutPropForwarding` option that can generate Svelte 5 runes-compatible layout prop forwarding.

--- a/packages/mdsvex/src/index.ts
+++ b/packages/mdsvex/src/index.ts
@@ -69,6 +69,7 @@ export function transform(
 		frontmatter,
 		smartypants,
 		highlight,
+		layoutPropForwarding,
 	} = {} as Omit<TransformOptions, 'layout_mode' | 'layout'>
 ): Processor & {
 	add_layouts: (layout: Layout, layout_mode: LayoutMode) => void;
@@ -110,7 +111,11 @@ export function transform(
 	};
 
 	processor.add_layouts = (layout: Layout, layout_mode: LayoutMode) => {
-		processor.use(transform_hast, { layout: layout, layout_mode });
+		processor.use(transform_hast, {
+			layout: layout,
+			layout_mode,
+			layoutPropForwarding,
+		});
 	};
 
 	return processor;
@@ -249,6 +254,7 @@ export const mdsvex = (options: MdsvexOptions = defaults): Preprocessor => {
 		layout = false,
 		highlight = { highlighter: code_highlight, optimise: true },
 		frontmatter,
+		layoutPropForwarding = 'legacy',
 	} = options;
 
 	if (highlight === undefined) {
@@ -279,6 +285,7 @@ export const mdsvex = (options: MdsvexOptions = defaults): Preprocessor => {
 		'layout',
 		'highlight',
 		'frontmatter',
+		'layoutPropForwarding',
 	];
 
 	for (const opt in options) {
@@ -293,6 +300,12 @@ export const mdsvex = (options: MdsvexOptions = defaults): Preprocessor => {
 		);
 	}
 
+	if (layoutPropForwarding !== 'legacy' && layoutPropForwarding !== 'runes') {
+		throw new Error(
+			`mdsvex: "layoutPropForwarding" must be either "legacy" or "runes".`
+		);
+	}
+
 	let layouts_processed: Promise<void> | undefined = undefined;
 
 	const parser = transform({
@@ -301,6 +314,7 @@ export const mdsvex = (options: MdsvexOptions = defaults): Preprocessor => {
 		smartypants,
 		highlight,
 		frontmatter,
+		layoutPropForwarding,
 	});
 
 	return {

--- a/packages/mdsvex/src/transformers/index.ts
+++ b/packages/mdsvex/src/transformers/index.ts
@@ -27,6 +27,7 @@ import type {
 	LayoutMode,
 	Layout,
 	LayoutMeta,
+	LayoutPropForwarding,
 } from '../types';
 
 let path: typeof import('path');
@@ -35,6 +36,7 @@ let path: typeof import('path');
 // this needs a big old cleanup
 
 const newline = '\n';
+const layout_props_name = '__mdsvex_generated_layout_props';
 // extract the yaml from 'yaml' nodes and put them in the vfil for later use
 
 export function default_frontmatter(
@@ -302,6 +304,74 @@ function generate_layout({
 	];
 }
 
+function node_contains_props_rune(node: any): boolean {
+	if (!node || typeof node !== 'object') return false;
+
+	if (
+		node.type === 'CallExpression' &&
+		node.callee &&
+		node.callee.type === 'Identifier' &&
+		node.callee.name === '$props'
+	) {
+		return true;
+	}
+
+	for (const key in node) {
+		if (key === 'parent') continue;
+
+		const value = node[key];
+		if (Array.isArray(value)) {
+			for (let i = 0; i < value.length; i += 1) {
+				if (node_contains_props_rune(value[i])) return true;
+			}
+		} else if (value && typeof value === 'object') {
+			if (node_contains_props_rune(value)) return true;
+		}
+	}
+
+	return false;
+}
+
+function script_contains_props_rune(script: string): boolean {
+	try {
+		// @ts-ignore
+		const result = parse(script);
+		return node_contains_props_rune(result.instance && result.instance.content);
+	} catch (e) {
+		return false;
+	}
+}
+
+function create_props_rune_conflict_error(filename: string): Error {
+	return new Error(
+		`mdsvex: Cannot combine \`layoutPropForwarding: "runes"\` with \`$props()\` inside an .svx file that uses an mdsvex layout.\n\n` +
+			`mdsvex generates \`const __mdsvex_generated_layout_props = $props();\` so it can forward document props to your layout. Svelte allows only one \`$props()\` call per component.\n\n` +
+			`Move page-specific values to frontmatter metadata instead.\n\n` +
+			`Invalid:\n` +
+			`<script>\n` +
+			`  let { title } = $props();\n` +
+			`</script>\n\n` +
+			`Valid:\n` +
+			`---\n` +
+			`title: My page title\n` +
+			`---\n\n` +
+			`Use \`metadata.title\` in the .svx file or read the \`title\` prop directly in the layout.\n\n` +
+			`File: ${filename}`
+	);
+}
+
+function create_layout_props_name(script: string | undefined): string {
+	let name = layout_props_name;
+	let i = 1;
+
+	while (script && script.includes(name)) {
+		name = `${layout_props_name}_${i}`;
+		i += 1;
+	}
+
+	return name;
+}
+
 export const handle_path = async (): Promise<void> => {
 	path = await import('path');
 };
@@ -309,9 +379,11 @@ export const handle_path = async (): Promise<void> => {
 export function transform_hast({
 	layout,
 	layout_mode,
+	layoutPropForwarding,
 }: {
 	layout: Layout | undefined;
 	layout_mode: LayoutMode;
+	layoutPropForwarding?: LayoutPropForwarding;
 }): Transformer {
 	return function transformer(tree, vFile) {
 		// we need to keep { and } intact for svelte, so reverse the escaping in links and images
@@ -378,8 +450,22 @@ export function transform_hast({
 				//@ts-ignore
 				filename: vFile.filename,
 			});
+			const use_runes_layout_props = layoutPropForwarding === 'runes';
+			const layout_props = create_layout_props_name(
+				instance[0] && (instance[0].value as string)
+			);
 
 			if (error) vFile.messages.push(new Message(error.reason));
+
+			if (
+				import_script &&
+				use_runes_layout_props &&
+				instance[0] &&
+				script_contains_props_rune(instance[0].value as string)
+			) {
+				//@ts-ignore
+				throw create_props_rune_conflict_error(vFile.filename);
+			}
 
 			if (components) {
 				for (let i = 0; i < components.length; i++) {
@@ -395,12 +481,20 @@ export function transform_hast({
 			if (import_script && !instance[0]) {
 				instance.push({
 					type: 'raw',
-					value: `${newline}<script>${newline}\t${import_script}${newline}</script>${newline}`,
+					value: `${newline}<script>${newline}\t${import_script}${
+						use_runes_layout_props
+							? `${newline}\tconst ${layout_props} = $props();`
+							: ''
+					}${newline}</script>${newline}`,
 				});
 			} else if (import_script) {
 				instance[0].value = (instance[0].value as string).replace(
 					RE_SCRIPT,
-					`$1${newline}\t${import_script}`
+					`$1${newline}\t${import_script}${
+						use_runes_layout_props
+							? `${newline}\tconst ${layout_props} = $props();`
+							: ''
+					}`
 				);
 			}
 
@@ -443,9 +537,9 @@ export function transform_hast({
 					//@ts-ignore
 					type: 'raw',
 					value: import_script
-						? `<Layout_MDSVEX_DEFAULT {...$$props}${
-								fm ? ' {...metadata}' : ''
-						  }>`
+						? `<Layout_MDSVEX_DEFAULT {...${
+								use_runes_layout_props ? layout_props : '$$props'
+						  }}${fm ? ' {...metadata}' : ''}>`
 						: '',
 				},
 				//@ts-ignore

--- a/packages/mdsvex/src/transformers/index.ts
+++ b/packages/mdsvex/src/transformers/index.ts
@@ -37,6 +37,8 @@ let path: typeof import('path');
 
 const newline = '\n';
 const layout_props_name = '__mdsvex_generated_layout_props';
+const layout_rest_props_name = '__mdsvex_generated_layout_rest';
+const layout_prop_name_prefix = '__mdsvex_generated_layout_prop_';
 // extract the yaml from 'yaml' nodes and put them in the vfil for later use
 
 export function default_frontmatter(
@@ -332,44 +334,182 @@ function node_contains_props_rune(node: any): boolean {
 	return false;
 }
 
-function script_contains_props_rune(script: string): boolean {
-	try {
-		// @ts-ignore
-		const result = parse(script);
-		return node_contains_props_rune(result.instance && result.instance.content);
-	} catch (e) {
-		return false;
+function create_generated_name(script: string, base: string): string {
+	let name = base;
+	let i = 1;
+
+	while (script.includes(name)) {
+		name = `${base}_${i}`;
+		i += 1;
 	}
+
+	return name;
 }
 
 function create_props_rune_conflict_error(filename: string): Error {
 	return new Error(
-		`mdsvex: Cannot combine \`layoutPropForwarding: "runes"\` with \`$props()\` inside an .svx file that uses an mdsvex layout.\n\n` +
-			`mdsvex generates \`const __mdsvex_generated_layout_props = $props();\` so it can forward document props to your layout. Svelte allows only one \`$props()\` call per component.\n\n` +
-			`Move page-specific values to frontmatter metadata instead.\n\n` +
-			`Invalid:\n` +
-			`<script>\n` +
-			`  let { title } = $props();\n` +
-			`</script>\n\n` +
-			`Valid:\n` +
-			`---\n` +
-			`title: My page title\n` +
-			`---\n\n` +
-			`Use \`metadata.title\` in the .svx file or read the \`title\` prop directly in the layout.\n\n` +
+		`mdsvex: Cannot forward \`$props()\` to an mdsvex layout from this .svx file.\n\n` +
+			`Use a top level object destructuring declaration such as \`let { title } = $props();\`, or bind the object directly with \`let props = $props();\`.\n\n` +
 			`File: ${filename}`
 	);
 }
 
 function create_layout_props_name(script: string | undefined): string {
-	let name = layout_props_name;
-	let i = 1;
+	return create_generated_name(script || '', layout_props_name);
+}
 
-	while (script && script.includes(name)) {
-		name = `${layout_props_name}_${i}`;
-		i += 1;
+function get_line_indentation(source: string, index: number): string {
+	const line_start = source.lastIndexOf(newline, index - 1) + 1;
+	const line = source.slice(line_start, index);
+	const match = line.match(/^\s*/);
+	return match ? match[0] : '';
+}
+
+function get_layout_prop_name(property: any): string | false {
+	if (property.computed) return false;
+	if (property.key.type === 'Identifier') return property.key.name;
+	if (property.key.type === 'Literal' && typeof property.key.value === 'string')
+		return property.key.value;
+	return false;
+}
+
+function transform_props_rune_declaration(
+	script: string,
+	declaration: any,
+	variable_declaration: any
+): { script: string; attributes: string } | false {
+	if (declaration.id.type === 'Identifier') {
+		return {
+			script,
+			attributes: `{...${declaration.id.name}}`,
+		};
 	}
 
-	return name;
+	if (declaration.id.type !== 'ObjectPattern') return false;
+
+	const properties = declaration.id.properties as any[];
+	const rest_property = properties.find(
+		(property) => property.type === 'RestElement'
+	);
+	const named_properties = properties.filter(
+		(property) => property.type === 'Property'
+	);
+	const forwarding_properties: Array<{
+		property_name: string;
+		key_source: string;
+	}> = [];
+
+	for (let i = 0; i < named_properties.length; i += 1) {
+		const property_name = get_layout_prop_name(named_properties[i]);
+		if (property_name === false) return false;
+		if (
+			property_name !== 'children' &&
+			!forwarding_properties.some(
+				(property) => property.property_name === property_name
+			)
+		)
+			forwarding_properties.push({
+				property_name,
+				key_source: script.slice(
+					named_properties[i].key.start,
+					named_properties[i].key.end
+				),
+			});
+	}
+
+	if (
+		rest_property &&
+		(!rest_property.argument || rest_property.argument.type !== 'Identifier')
+	)
+		return false;
+
+	const declaration_indentation = get_line_indentation(
+		script,
+		variable_declaration.start
+	);
+	const property_indentation = `${declaration_indentation}  `;
+	const generated_names = new Set<string>();
+	const raw_properties = forwarding_properties.map(
+		({ property_name, key_source }) => {
+			const safe_name = property_name.replace(/[^A-Za-z0-9_$]/g, '_');
+			const base = `${layout_prop_name_prefix}${safe_name}`;
+			let name = create_generated_name(script, base);
+			let i = 1;
+
+			while (generated_names.has(name)) {
+				name = `${base}_${i}`;
+				i += 1;
+			}
+
+			generated_names.add(name);
+			return { property_name, key_source, name };
+		}
+	);
+	const rest_name = rest_property
+		? rest_property.argument.name
+		: create_generated_name(script, layout_rest_props_name);
+	const original_properties = named_properties.map((property) =>
+		script.slice(property.start, property.end)
+	);
+	const generated_properties = raw_properties.map(
+		({ key_source, name }) => `${key_source}: ${name}`
+	);
+	const rest_source = rest_property
+		? script.slice(rest_property.start, rest_property.end)
+		: `...${rest_name}`;
+	const replacement =
+		`{${newline}` +
+		[...original_properties, ...generated_properties, rest_source]
+			.map((property) => `${property_indentation}${property}`)
+			.join(`,${newline}`) +
+		`${newline}${declaration_indentation}}`;
+	const attributes = [
+		`{...${rest_name}}`,
+		...raw_properties.map(
+			({ property_name, name }) => `${property_name}={${name}}`
+		),
+	].join(' ');
+
+	return {
+		script:
+			script.slice(0, declaration.id.start) +
+			replacement +
+			script.slice(declaration.id.end),
+		attributes,
+	};
+}
+
+function get_props_rune_layout_forwarding(
+	script: string
+): { script: string; attributes: string } | false | undefined {
+	try {
+		// @ts-ignore
+		const result = parse(script);
+		const instance = result.instance && result.instance.content;
+		if (!instance) return undefined;
+
+		for (let i = 0; i < instance.body.length; i += 1) {
+			const statement = instance.body[i];
+			if (statement.type !== 'VariableDeclaration') continue;
+
+			for (let j = 0; j < statement.declarations.length; j += 1) {
+				const declaration = statement.declarations[j];
+				if (
+					!declaration.init ||
+					declaration.init.type !== 'CallExpression' ||
+					declaration.init.callee.type !== 'Identifier' ||
+					declaration.init.callee.name !== '$props'
+				)
+					continue;
+
+				return transform_props_rune_declaration(script, declaration, statement);
+			}
+		}
+
+		return node_contains_props_rune(instance) ? false : undefined;
+	} catch (e) {
+		return undefined;
+	}
 }
 
 export const handle_path = async (): Promise<void> => {
@@ -451,20 +591,28 @@ export function transform_hast({
 				filename: vFile.filename,
 			});
 			const use_runes_layout_props = layoutPropForwarding === 'runes';
+			const runes_layout_forwarding =
+				import_script && use_runes_layout_props && instance[0]
+					? get_props_rune_layout_forwarding(instance[0].value as string)
+					: undefined;
 			const layout_props = create_layout_props_name(
 				instance[0] && (instance[0].value as string)
 			);
+			const layout_attributes = use_runes_layout_props
+				? runes_layout_forwarding
+					? runes_layout_forwarding.attributes
+					: `{...${layout_props}}`
+				: '{...$$props}';
 
 			if (error) vFile.messages.push(new Message(error.reason));
 
-			if (
-				import_script &&
-				use_runes_layout_props &&
-				instance[0] &&
-				script_contains_props_rune(instance[0].value as string)
-			) {
+			if (runes_layout_forwarding === false) {
 				//@ts-ignore
 				throw create_props_rune_conflict_error(vFile.filename);
+			}
+
+			if (runes_layout_forwarding && instance[0]) {
+				instance[0].value = runes_layout_forwarding.script;
 			}
 
 			if (components) {
@@ -482,7 +630,7 @@ export function transform_hast({
 				instance.push({
 					type: 'raw',
 					value: `${newline}<script>${newline}\t${import_script}${
-						use_runes_layout_props
+						use_runes_layout_props && !runes_layout_forwarding
 							? `${newline}\tconst ${layout_props} = $props();`
 							: ''
 					}${newline}</script>${newline}`,
@@ -491,7 +639,7 @@ export function transform_hast({
 				instance[0].value = (instance[0].value as string).replace(
 					RE_SCRIPT,
 					`$1${newline}\t${import_script}${
-						use_runes_layout_props
+						use_runes_layout_props && !runes_layout_forwarding
 							? `${newline}\tconst ${layout_props} = $props();`
 							: ''
 					}`
@@ -537,9 +685,9 @@ export function transform_hast({
 					//@ts-ignore
 					type: 'raw',
 					value: import_script
-						? `<Layout_MDSVEX_DEFAULT {...${
-								use_runes_layout_props ? layout_props : '$$props'
-						  }}${fm ? ' {...metadata}' : ''}>`
+						? `<Layout_MDSVEX_DEFAULT ${layout_attributes}${
+								fm ? ' {...metadata}' : ''
+						  }>`
 						: '',
 				},
 				//@ts-ignore

--- a/packages/mdsvex/src/types.ts
+++ b/packages/mdsvex/src/types.ts
@@ -5,6 +5,7 @@ import type { Text } from 'mdast';
 import type { Plugin, Settings } from 'unified';
 
 export type LayoutMode = 'named' | 'single';
+export type LayoutPropForwarding = 'legacy' | 'runes';
 
 export type parser_frontmatter_options = {
 	parse: (
@@ -207,6 +208,7 @@ export interface TransformOptions {
 	layout?: Layout;
 	highlight?: HighlightOptions | false;
 	layout_mode?: LayoutMode;
+	layoutPropForwarding?: LayoutPropForwarding;
 }
 
 /**
@@ -296,6 +298,15 @@ export interface MdsvexOptions {
 	 * ```
 	 */
 	layout?: string | Record<string, string>;
+	/**
+	 * **layoutPropForwarding** - How mdsvex forwards document props to layout components. Default: `"legacy"`.
+	 *
+	 *  *example:*
+	 * ```js
+	 * layoutPropForwarding: "runes"
+	 * ```
+	 */
+	layoutPropForwarding?: LayoutPropForwarding;
 }
 
 /**

--- a/packages/mdsvex/test/it/mdsvex.spec.ts
+++ b/packages/mdsvex/test/it/mdsvex.spec.ts
@@ -550,47 +550,253 @@ test('runes mode layout output should compile with Svelte 5', async () => {
 	).not.toThrow();
 });
 
-test('runes mode layout output should fail clearly when an mdsvex file already calls $props', async () => {
-	let error: Error | undefined;
-
-	try {
-		await mdsvex({
-			layout: join(fix_dir, 'Layout.svelte'),
-			layoutPropForwarding: 'runes',
-		}).markup({
-			content: `
+test('runes mode layout output should forward destructured props', async () => {
+	const output = await mdsvex({
+		layout: join(fix_dir, 'Layout.svelte'),
+		layoutPropForwarding: 'runes',
+	}).markup({
+		content: `
 <svelte:options runes={true} />
 
 <script>
   let { title } = $props();
 </script>
 
-# hello`,
-			filename: 'file.svx',
-		});
-	} catch (e) {
-		error = e as Error;
-	}
+# {title}`,
+		filename: 'file.svx',
+	});
 
-	expect(error).toBeDefined();
-	expect(error?.message).toContain(
-		'mdsvex: Cannot combine `layoutPropForwarding: "runes"` with `$props()` inside an .svx file that uses an mdsvex layout.'
+	expect(lines(output?.code)).toEqual(
+		lines(`<script>
+	import Layout_MDSVEX_DEFAULT from '${to_posix(join(fix_dir, 'Layout.svelte'))}';
+  let {
+    title,
+    title: __mdsvex_generated_layout_prop_title,
+    ...__mdsvex_generated_layout_rest
+  } = $props();
+</script>
+
+<svelte:options runes={true} />
+<Layout_MDSVEX_DEFAULT {...__mdsvex_generated_layout_rest} title={__mdsvex_generated_layout_prop_title}>
+
+<h1>{title}</h1>
+</Layout_MDSVEX_DEFAULT>`)
 	);
-	expect(error?.message).toContain(
-		'mdsvex generates `const __mdsvex_generated_layout_props = $props();`'
+
+	expect(() =>
+		compile_svelte(output?.code ?? '', {
+			filename: 'file.svx',
+			generate: false,
+		})
+	).not.toThrow();
+});
+
+test('runes mode layout output should preserve raw props for fallbacks and aliases', async () => {
+	const output = await mdsvex({
+		layout: join(fix_dir, 'Layout.svelte'),
+		layoutPropForwarding: 'runes',
+	}).markup({
+		content: `
+<svelte:options runes={true} />
+
+<script>
+  let { title = 'Untitled', subtitle: local_subtitle } = $props();
+</script>
+
+# {title}
+
+{local_subtitle}`,
+		filename: 'file.svx',
+	});
+
+	expect(lines(output?.code)).toEqual(
+		lines(`<script>
+	import Layout_MDSVEX_DEFAULT from '${to_posix(join(fix_dir, 'Layout.svelte'))}';
+  let {
+    title = 'Untitled',
+    subtitle: local_subtitle,
+    title: __mdsvex_generated_layout_prop_title,
+    subtitle: __mdsvex_generated_layout_prop_subtitle,
+    ...__mdsvex_generated_layout_rest
+  } = $props();
+</script>
+
+<svelte:options runes={true} />
+<Layout_MDSVEX_DEFAULT {...__mdsvex_generated_layout_rest} title={__mdsvex_generated_layout_prop_title} subtitle={__mdsvex_generated_layout_prop_subtitle}>
+
+<h1>{title}</h1>
+<p>{local_subtitle}</p>
+</Layout_MDSVEX_DEFAULT>`)
 	);
-	expect(error?.message).toContain(
-		'Svelte allows only one `$props()` call per component.'
+
+	expect(output?.code).not.toContain('title={title}');
+	expect(output?.code).not.toContain('subtitle={local_subtitle}');
+	expect(() =>
+		compile_svelte(output?.code ?? '', {
+			filename: 'file.svx',
+			generate: false,
+		})
+	).not.toThrow();
+});
+
+test('runes mode layout output should forward quoted prop keys', async () => {
+	const output = await mdsvex({
+		layout: join(fix_dir, 'Layout.svelte'),
+		layoutPropForwarding: 'runes',
+	}).markup({
+		content: `
+<svelte:options runes={true} />
+
+<script>
+  let { 'data-id': data_id } = $props();
+</script>
+
+{data_id}`,
+		filename: 'file.svx',
+	});
+
+	expect(output?.code).toContain(
+		"'data-id': __mdsvex_generated_layout_prop_data_id"
 	);
-	expect(error?.message).toContain(
-		'Move page-specific values to frontmatter metadata instead.'
+	expect(output?.code).toContain(
+		'<Layout_MDSVEX_DEFAULT {...__mdsvex_generated_layout_rest} data-id={__mdsvex_generated_layout_prop_data_id}>'
 	);
-	expect(error?.message).toContain('let { title } = $props();');
-	expect(error?.message).toContain('title: My page title');
-	expect(error?.message).toContain(
-		'Use `metadata.title` in the .svx file or read the `title` prop directly in the layout.'
+	expect(() =>
+		compile_svelte(output?.code ?? '', {
+			filename: 'file.svx',
+			generate: false,
+		})
+	).not.toThrow();
+});
+
+test('runes mode layout output should reuse existing rest props and preserve bindable props', async () => {
+	const output = await mdsvex({
+		layout: join(fix_dir, 'Layout.svelte'),
+		layoutPropForwarding: 'runes',
+	}).markup({
+		content: `
+<svelte:options runes={true} />
+
+<script>
+  let { value = $bindable(), ...other } = $props();
+</script>
+
+<input bind:value />`,
+		filename: 'file.svx',
+	});
+
+	expect(lines(output?.code)).toEqual(
+		lines(`<script>
+	import Layout_MDSVEX_DEFAULT from '${to_posix(join(fix_dir, 'Layout.svelte'))}';
+  let {
+    value = $bindable(),
+    value: __mdsvex_generated_layout_prop_value,
+    ...other
+  } = $props();
+</script>
+
+<svelte:options runes={true} />
+<Layout_MDSVEX_DEFAULT {...other} value={__mdsvex_generated_layout_prop_value}>
+
+<input bind:value />
+</Layout_MDSVEX_DEFAULT>`)
 	);
-	expect(error?.message).toContain('File: file.svx');
+
+	expect(output?.code).not.toContain('value={value}');
+	expect(() =>
+		compile_svelte(output?.code ?? '', {
+			filename: 'file.svx',
+			generate: false,
+		})
+	).not.toThrow();
+});
+
+test('runes mode layout output should preserve frontmatter precedence and markdown children', async () => {
+	const output = await mdsvex({
+		layout: join(fix_dir, 'Layout.svelte'),
+		layoutPropForwarding: 'runes',
+	}).markup({
+		content: `---
+title: From frontmatter
+---
+
+<svelte:options runes={true} />
+
+<script>
+  let { title, children } = $props();
+</script>
+
+# {title}`,
+		filename: 'file.svx',
+	});
+
+	expect(lines(output?.code)).toEqual(
+		lines(`<script context="module">
+	export const metadata = {"title":"From frontmatter"};
+	const { title } = metadata;
+</script>
+
+<script>
+	import Layout_MDSVEX_DEFAULT from '${to_posix(join(fix_dir, 'Layout.svelte'))}';
+  let {
+    title,
+    children,
+    title: __mdsvex_generated_layout_prop_title,
+    ...__mdsvex_generated_layout_rest
+  } = $props();
+</script>
+
+<svelte:options runes={true} />
+<Layout_MDSVEX_DEFAULT {...__mdsvex_generated_layout_rest} title={__mdsvex_generated_layout_prop_title} {...metadata}>
+
+<h1>{title}</h1>
+</Layout_MDSVEX_DEFAULT>`)
+	);
+
+	expect(output?.code).not.toContain('children={');
+	expect(() =>
+		compile_svelte(output?.code ?? '', {
+			filename: 'file.svx',
+			generate: false,
+		})
+	).not.toThrow();
+});
+
+test('runes mode layout output should preserve typed destructuring and avoid forwarding name collisions', async () => {
+	const output = await mdsvex({
+		layout: join(fix_dir, 'Layout.svelte'),
+		layoutPropForwarding: 'runes',
+	}).markup({
+		content: `
+<svelte:options runes={true} />
+
+<script lang="ts">
+  interface Props {
+    title: string;
+  }
+
+  const __mdsvex_generated_layout_prop_title = '';
+  const __mdsvex_generated_layout_rest = {};
+  let { title }: Props = $props();
+</script>
+
+# {title}`,
+		filename: 'file.svx',
+	});
+
+	expect(output?.code).toContain(
+		'title: __mdsvex_generated_layout_prop_title_1'
+	);
+	expect(output?.code).toContain('...__mdsvex_generated_layout_rest_1');
+	expect(output?.code).toContain(
+		'<Layout_MDSVEX_DEFAULT {...__mdsvex_generated_layout_rest_1} title={__mdsvex_generated_layout_prop_title_1}>'
+	);
+	expect(() =>
+		compile_svelte(output?.code ?? '', {
+			filename: 'file.svx',
+			generate: false,
+		})
+	).not.toThrow();
 });
 
 test('runes mode layout output should avoid generated props name collisions', async () => {

--- a/packages/mdsvex/test/it/mdsvex.spec.ts
+++ b/packages/mdsvex/test/it/mdsvex.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect, vi } from 'vitest';
 import { Node, Parent } from 'unist';
+import { compile as compile_svelte } from 'svelte/compiler';
 
 import { join } from 'path';
 import { lines } from '../utils';
@@ -391,6 +392,235 @@ test('custom layouts should work - when there are script tags with random attrib
 
 </Layout_MDSVEX_DEFAULT>`)
 	);
+});
+
+test('custom layouts should support runes mode output', async () => {
+	const output = await mdsvex({
+		layout: join(fix_dir, 'Layout.svelte'),
+		layoutPropForwarding: 'runes',
+	}).markup({
+		content: `
+<svelte:options runes={true} />
+
+# hello`,
+		filename: 'file.svx',
+	});
+
+	expect(lines(output?.code)).toEqual(
+		lines(`
+<script>
+	import Layout_MDSVEX_DEFAULT from '${to_posix(join(fix_dir, 'Layout.svelte'))}';
+	const __mdsvex_generated_layout_props = $props();
+</script>
+
+<svelte:options runes={true} />
+<Layout_MDSVEX_DEFAULT {...__mdsvex_generated_layout_props}>
+
+<h1>hello</h1>
+</Layout_MDSVEX_DEFAULT>`)
+	);
+});
+
+test('custom layouts should support runes mode output with an existing script', async () => {
+	const output = await mdsvex({
+		layout: join(fix_dir, 'Layout.svelte'),
+		layoutPropForwarding: 'runes',
+	}).markup({
+		content: `
+<svelte:options runes={true} />
+
+<script>
+  let count = 0;
+</script>
+
+# hello`,
+		filename: 'file.svx',
+	});
+
+	expect(lines(output?.code)).toEqual(
+		lines(`<script>
+	import Layout_MDSVEX_DEFAULT from '${to_posix(join(fix_dir, 'Layout.svelte'))}';
+	const __mdsvex_generated_layout_props = $props();
+  let count = 0;
+</script>
+
+<svelte:options runes={true} />
+<Layout_MDSVEX_DEFAULT {...__mdsvex_generated_layout_props}>
+
+<h1>hello</h1>
+</Layout_MDSVEX_DEFAULT>`)
+	);
+});
+
+test('custom layouts should support runes mode output with an existing TypeScript script and frontmatter', async () => {
+	const output = await mdsvex({
+		layout: join(fix_dir, 'Layout.svelte'),
+		layoutPropForwarding: 'runes',
+	}).markup({
+		content: `---
+string: value
+---
+
+<svelte:options runes={true} />
+
+<script lang="ts">
+  let count: number = 0;
+</script>
+
+# hello`,
+		filename: 'file.svx',
+	});
+
+	expect(lines(output?.code)).toEqual(
+		lines(`<script context="module">
+	export const metadata = {"string":"value"};
+	const { string } = metadata;
+</script>
+
+<script lang="ts">
+	import Layout_MDSVEX_DEFAULT from '${to_posix(join(fix_dir, 'Layout.svelte'))}';
+	const __mdsvex_generated_layout_props = $props();
+  let count: number = 0;
+</script>
+
+<svelte:options runes={true} />
+<Layout_MDSVEX_DEFAULT {...__mdsvex_generated_layout_props} {...metadata}>
+
+<h1>hello</h1>
+</Layout_MDSVEX_DEFAULT>`)
+	);
+});
+
+test('runes mode layout output should compile with Svelte 5', async () => {
+	const no_layout_output = await mdsvex().markup({
+		content: `
+<svelte:options runes={true} />
+
+<MyComponent />
+
+# hello`,
+		filename: 'file.svx',
+	});
+
+	expect(no_layout_output?.code).not.toContain('$$props');
+	expect(() =>
+		compile_svelte(no_layout_output?.code ?? '', {
+			filename: 'file.svx',
+			generate: false,
+		})
+	).not.toThrow();
+
+	const legacy_output = await mdsvex({
+		layout: join(fix_dir, 'Layout.svelte'),
+	}).markup({
+		content: `
+<svelte:options runes={true} />
+
+# hello`,
+		filename: 'file.svx',
+	});
+
+	expect(() =>
+		compile_svelte(legacy_output?.code ?? '', {
+			filename: 'file.svx',
+			generate: false,
+		})
+	).toThrow('Cannot use `$$props` in runes mode');
+
+	const runes_output = await mdsvex({
+		layout: join(fix_dir, 'Layout.svelte'),
+		layoutPropForwarding: 'runes',
+	}).markup({
+		content: `
+<svelte:options runes={true} />
+
+# hello`,
+		filename: 'file.svx',
+	});
+
+	expect(runes_output?.code).toContain(
+		'<Layout_MDSVEX_DEFAULT {...__mdsvex_generated_layout_props}>'
+	);
+
+	expect(() =>
+		compile_svelte(runes_output?.code ?? '', {
+			filename: 'file.svx',
+			generate: false,
+		})
+	).not.toThrow();
+});
+
+test('runes mode layout output should fail clearly when an mdsvex file already calls $props', async () => {
+	let error: Error | undefined;
+
+	try {
+		await mdsvex({
+			layout: join(fix_dir, 'Layout.svelte'),
+			layoutPropForwarding: 'runes',
+		}).markup({
+			content: `
+<svelte:options runes={true} />
+
+<script>
+  let { title } = $props();
+</script>
+
+# hello`,
+			filename: 'file.svx',
+		});
+	} catch (e) {
+		error = e as Error;
+	}
+
+	expect(error).toBeDefined();
+	expect(error?.message).toContain(
+		'mdsvex: Cannot combine `layoutPropForwarding: "runes"` with `$props()` inside an .svx file that uses an mdsvex layout.'
+	);
+	expect(error?.message).toContain(
+		'mdsvex generates `const __mdsvex_generated_layout_props = $props();`'
+	);
+	expect(error?.message).toContain(
+		'Svelte allows only one `$props()` call per component.'
+	);
+	expect(error?.message).toContain(
+		'Move page-specific values to frontmatter metadata instead.'
+	);
+	expect(error?.message).toContain('let { title } = $props();');
+	expect(error?.message).toContain('title: My page title');
+	expect(error?.message).toContain(
+		'Use `metadata.title` in the .svx file or read the `title` prop directly in the layout.'
+	);
+	expect(error?.message).toContain('File: file.svx');
+});
+
+test('runes mode layout output should avoid generated props name collisions', async () => {
+	const output = await mdsvex({
+		layout: join(fix_dir, 'Layout.svelte'),
+		layoutPropForwarding: 'runes',
+	}).markup({
+		content: `
+<svelte:options runes={true} />
+
+<script>
+  const __mdsvex_generated_layout_props = {};
+</script>
+
+# hello`,
+		filename: 'file.svx',
+	});
+
+	expect(output?.code).toContain(
+		'const __mdsvex_generated_layout_props_1 = $props();'
+	);
+	expect(output?.code).toContain(
+		'<Layout_MDSVEX_DEFAULT {...__mdsvex_generated_layout_props_1}>'
+	);
+	expect(() =>
+		compile_svelte(output?.code ?? '', {
+			filename: 'file.svx',
+			generate: false,
+		})
+	).not.toThrow();
 });
 
 test('custom layouts should work - when everything is in a random order', async () => {
@@ -788,10 +1018,21 @@ number: 999
 	await output_fn();
 
 	expect(warning).toEqual(
-		'mdsvex: Received unknown options: bip, bop, boom. Valid options are: filename, remarkPlugins, rehypePlugins, smartypants, extension, extensions, layout, highlight, frontmatter.'
+		'mdsvex: Received unknown options: bip, bop, boom. Valid options are: filename, remarkPlugins, rehypePlugins, smartypants, extension, extensions, layout, highlight, frontmatter, layoutPropForwarding.'
 	);
 
 	console.warn = console_warn;
+});
+
+test('Throw on invalid layoutPropForwarding option', () => {
+	expect(() =>
+		mdsvex({
+			//@ts-ignore
+			layoutPropForwarding: 'oops',
+		})
+	).toThrow(
+		'mdsvex: "layoutPropForwarding" must be either "legacy" or "runes".'
+	);
 });
 
 test('Custom layout can be set via frontmatter - strange formatting', async () => {

--- a/packages/site/src/routes/_docs.svtext
+++ b/packages/site/src/routes/_docs.svtext
@@ -148,6 +148,7 @@ interface MdsvexOptions {
 	extensions: string[];
 	smartypants: boolean | smartypantsOptions;
 	layout: string | { [name: string]: string };
+	layoutPropForwarding: "legacy" | "runes";
 	remarkPlugins: Array<plugin> | Array<[plugin, plugin_options]>;
 	rehypePlugins: Array<plugin> | Array<[plugin, plugin_options]>;
 	highlight: { highlighter: Function, alias: { [alias]: lang }, optimise: boolean };
@@ -322,6 +323,71 @@ mdsvex({
 		_: "./path/to/fallback/layout.svelte"
 	}
 });
+```
+
+### `layoutPropForwarding`
+
+```ts
+layoutPropForwarding: "legacy" | "runes" = "legacy";
+```
+
+When mdsvex applies a layout, it forwards document props to that layout. By default mdsvex uses Svelte's legacy all-props syntax:
+
+```svelte
+<Layout_MDSVEX_DEFAULT {...$$props}>
+```
+
+Svelte 5 runes mode does not allow `$$props`. If your mdsvex files use runes mode and also use mdsvex layouts, set `layoutPropForwarding` to `"runes"`:
+
+```js
+import { fileURLToPath } from "node:url";
+
+const layout = fileURLToPath(new URL("./src/Layout.svelte", import.meta.url));
+
+mdsvex({
+	layout,
+	layoutPropForwarding: "runes"
+});
+```
+
+This generates runes-compatible layout prop forwarding:
+
+```svelte
+<script>
+	import Layout_MDSVEX_DEFAULT from "./path/to/layout.svelte";
+	const __mdsvex_generated_layout_props = $props();
+</script>
+
+<Layout_MDSVEX_DEFAULT {...__mdsvex_generated_layout_props}>
+```
+
+Svelte allows `$props()` to be called only once per component. When `layoutPropForwarding: "runes"` is enabled, mdsvex uses that one call to forward document props to the layout. Do not call `$props()` in the same `.svx` file:
+
+```svx
+<script>
+	let { title } = $props();
+</script>
+```
+
+Move page-specific values to frontmatter metadata instead:
+
+```svx
+---
+title: My page title
+---
+
+# {metadata.title}
+```
+
+The `.svx` file reads frontmatter through `metadata`, while the layout receives each frontmatter value as a prop:
+
+```svelte
+<script>
+	let { children, title } = $props();
+</script>
+
+<h1>{title}</h1>
+{@render children()}
 ```
 
 ### `remarkPlugins` / `rehypePlugins`

--- a/packages/site/src/routes/docs/+page.svelte
+++ b/packages/site/src/routes/docs/+page.svelte
@@ -28,6 +28,7 @@
 				['extensions', 'docs#extensions', true],
 				['smartypants', 'docs#smartypants', true],
 				['layout', 'docs#layout', true],
+				['layoutPropForwarding', 'docs#layoutpropforwarding', true],
 				['remarkPlugins', 'docs#remarkplugins--rehypeplugins', true],
 				['rehypePlugins', 'docs#remarkplugins--rehypeplugins', true],
 				['highlight', 'docs#highlight', true],


### PR DESCRIPTION
Fixes the Svelte 5 runes-mode error caused by mdsvex layouts generating `$$props`.  Fixes #738

  ## Changes

  - Add `layoutPropForwarding: 'runes'` for runes-compatible layout prop forwarding
  - Preserve legacy behavior by default
  - Fail with an actionable error when an `.svx` page already calls `$props()`
  - Document the configuration and frontmatter/layout prop behavior
  - Add coverage for generated output, compiler compatibility, conflicts, and name collisions

  ## Validation

  - `pnpm --filter mdsvex test -- test/it/mdsvex.spec.ts`
  - `pnpm lint`
  - `pnpm site:build`
  - Fresh SvelteKit/Svelte 5 app: reproduced legacy failure, applied the option, verified conflict guidance, built and server-rendered successfully