### PR TITLE
docs: fix unclosed </Layout> tag in layout example

### DIFF
--- a/packages/site/src/routes/_docs.svtext
+++ b/packages/site/src/routes/_docs.svtext
@@ -296,7 +296,7 @@ The `layout` option allows you to provide a custom layout component that will wr
 ```svelte
 <Layout>
  <MdsvexDocument />
-<Layout>
+</Layout>
 ```
 
 > Layout components receive all frontmatter values as props, which should provide a great deal of flexibility when designing your layouts.


### PR DESCRIPTION
The closing </Layout> tag is missing in the layout code example under the layout option section of the docs. Currently it renders as:

```svelte
<Layout>
 <MdsvexDocument />
<Layout>
```

Should be:

```svelte
<Layout>
 <MdsvexDocument />
</Layout>
```

Closes #273, closes #557.